### PR TITLE
Add lint step to CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,3 +27,5 @@ jobs:
       run: npm install
     - name: Run tests
       run: npm test
+    - name: Lint
+      run: npm run lint


### PR DESCRIPTION
We should run lint on CI. Since it will fail just for error-level lints, not warnings, we can use "being push blocking" as criteria to define the lint level.

Currently the only error-level lints are [no-var](https://eslint.org/docs/rules/no-var) and [eqeqeq](https://eslint.org/docs/rules/eqeqeq), both of which are rather important IMO.