### PR TITLE
No arbitrary sanity

### DIFF
--- a/src/arbitraries.ts
+++ b/src/arbitraries.ts
@@ -73,7 +73,7 @@ export abstract class Arbitrary<A> {
 // ---- Special Arbitraries ----
 // -----------------------------
 
-export const NoArbitrary: Arbitrary<never> = new class extends Arbitrary<never> {
+const NoArbitrary: Arbitrary<never> = new class extends Arbitrary<never> {
   size(): ArbitrarySize { return { value: 0, type: 'exact' } }
   sampleWithBias(_ = 0) { return [] }
   sample(_ = 0) { return [] }
@@ -387,5 +387,6 @@ export const nat     = (min = 0, max = Number.MAX_SAFE_INTEGER) => new Arbitrary
 export const array   = <A>(arbitrary: Arbitrary<A>, min = 0, max = 10) => new ArbitraryArray(arbitrary, min, max)
 export const union   = <A>(...arbitraries: Arbitrary<A>[]) => new ArbitraryComposite(arbitraries)
 export const boolean = () => new ArbitraryBoolean()
+export const empty   = () => NoArbitrary
 export const string  = (min = 2, max = 10, chars = 'abcdefghijklmnopqrstuvwxyz') =>
   new ArbitraryArray(integer(chars.charCodeAt(0), chars.charCodeAt(chars.length - 1)).map(c => String.fromCharCode(c)), min, max).map(chs => chs.join(''))

--- a/test/arbitrary.test.ts
+++ b/test/arbitrary.test.ts
@@ -221,18 +221,18 @@ describe('Arbitrary tests', () => {
 
   describe('No Arbitrary', () => {
     it('should return size == 0', () => {
-      expect(fc.NoArbitrary.size().value).to.eq(0)
+      expect(fc.empty().size().value).to.eq(0)
     })
 
     it('should return an empty sample', () => {
-      expect(fc.NoArbitrary.sample().length).to.eq(0)
-      expect(fc.NoArbitrary.sampleWithBias().length).to.eq(0)
+      expect(fc.empty().sample().length).to.eq(0)
+      expect(fc.empty().sampleWithBias().length).to.eq(0)
     })
 
     it('should remain no arbitrary when compose with unique, map, and filter', () => {
-      expect(fc.NoArbitrary.unique()).to.eq(fc.NoArbitrary)
-      expect(fc.NoArbitrary.map(a => a)).to.eq(fc.NoArbitrary)
-      expect(fc.NoArbitrary.filter(a => true)).to.eq(fc.NoArbitrary)
+      expect(fc.empty().unique()).to.eq(fc.empty())
+      expect(fc.empty().map(a => a)).to.eq(fc.empty())
+      expect(fc.empty().filter(a => true)).to.eq(fc.empty())
     })
   })
 })


### PR DESCRIPTION
The commit should be self-evident. I miss Scala's object companion so we could make class constructors private and control their instantiation.