### PR TITLE
Arbitrary toString()

### DIFF
--- a/src/arbitraries/Arbitrary.ts
+++ b/src/arbitraries/Arbitrary.ts
@@ -51,4 +51,6 @@ export abstract class Arbitrary<A> {
   filter(f: (a: A) => boolean): Arbitrary<A> { return new FilteredArbitrary(this, f) }
   chain<B>(f: (a: A) => Arbitrary<B>): Arbitrary<B> { return new ChainedArbitrary(this, f) }
   unique(): Arbitrary<A> { return new UniqueArbitrary(this) }
+
+  toString(depth = 0): string { return ' '.repeat(depth * 2) + `Base Arbitrary: ${this.constructor.name}`  }
 }

--- a/src/arbitraries/ArbitraryArray.ts
+++ b/src/arbitraries/ArbitraryArray.ts
@@ -53,4 +53,6 @@ export class ArbitraryArray<A> extends Arbitrary<A[]> {
       { value: Array(this.max).fill(cc.value), original: Array(this.max).fill(cc.original) }
     ]).filter(v => v !== undefined) as FluentPick<A[]>[]
   }
+
+  toString(depth = 0): string { return ' '.repeat(depth * 2) + `Array Arbitrary: min = ${this.min} max = ${this.max}\n${this.arbitrary.toString(depth + 1)}` }
 }

--- a/src/arbitraries/ArbitraryBoolean.ts
+++ b/src/arbitraries/ArbitraryBoolean.ts
@@ -6,4 +6,5 @@ export class ArbitraryBoolean extends MappedArbitrary<number, boolean> {
   constructor() { super(fc.integer(0, 1), x => x === 0) }
   shrink(_: FluentPick<boolean>) { return NoArbitrary }
   canGenerate(pick: FluentPick<boolean>) { return pick.value !== undefined}
+  toString(depth: number) { return ' '.repeat(2 * depth) + 'Boolean Arbitrary'}
 }

--- a/src/arbitraries/ArbitraryComposite.ts
+++ b/src/arbitraries/ArbitraryComposite.ts
@@ -31,4 +31,6 @@ export class ArbitraryComposite<A> extends Arbitrary<A> {
   canGenerate(pick: FluentPick<A>) {
     return this.arbitraries.some(a => a.canGenerate(pick))
   }
+
+  toString(depth: number) { return ' '.repeat(2 * depth) + 'Composite Arbitrary:\n' + this.arbitraries.map(a => a.toString(depth + 1)).join('\n')}
 }

--- a/src/arbitraries/ArbitraryConstant.ts
+++ b/src/arbitraries/ArbitraryConstant.ts
@@ -12,4 +12,5 @@ export class ArbitraryConstant<A> extends Arbitrary<A> {
   canGenerate(pick: FluentPick<A>) {
     return pick.value === this.constant
   }
+  toString(depth = 0): string { return ' '.repeat(depth * 2) + `Constant Arbitrary: ${this.constant}` }
 }

--- a/src/arbitraries/ArbitraryInteger.ts
+++ b/src/arbitraries/ArbitraryInteger.ts
@@ -11,7 +11,10 @@ export class ArbitraryInteger extends Arbitrary<number> {
 
   size(): ArbitrarySize { return { value: this.max - this.min + 1, type: 'exact' } }
 
-  pick() { return { value: Math.floor(Math.random() * (this.max - this.min + 1)) + this.min } }
+  pick() {
+    const value = Math.floor(Math.random() * (this.max - this.min + 1)) + this.min
+    return { value, original: value }
+  }
 
   cornerCases() {
     return (this.min < 0 && this.max > 0) ?
@@ -44,4 +47,6 @@ export class ArbitraryInteger extends Arbitrary<number> {
   canGenerate(pick: FluentPick<number>) {
     return pick.value >= this.min && pick.value <= this.max
   }
+
+  toString(depth = 0) { return ' '.repeat(depth * 2) + `Integer Arbitrary: min = ${this.min} max = ${this.max}`}
 }

--- a/src/arbitraries/ArbitraryReal.ts
+++ b/src/arbitraries/ArbitraryReal.ts
@@ -5,5 +5,8 @@ export class ArbitraryReal extends ArbitraryInteger {
     super(min, max)
   }
 
-  pick() { return { value: Math.random() * (this.max - this.min) + this.min } }
+  pick()  {
+    const value = Math.random() * (this.max - this.min) + this.min
+    return { value, original: value }
+  }
 }

--- a/src/arbitraries/ArbitrarySet.ts
+++ b/src/arbitraries/ArbitrarySet.ts
@@ -56,4 +56,6 @@ export class ArbitrarySet<A> extends Arbitrary<A[]> {
 
     return [{ value: min, original: min }, { value: max, original: max }]
   }
+
+  toString(depth = 0) { return ' '.repeat(depth * 2) + `Set Arbitrary: min = ${this.min} max = ${this.max} elements = [${this.elements.join(', ')}]`}
 }

--- a/src/arbitraries/ArbitraryTuple.ts
+++ b/src/arbitraries/ArbitraryTuple.ts
@@ -25,6 +25,7 @@ export class ArbitraryTuple<U extends Arbitrary<any>[], A = UnwrapFluentPick<U>>
   pick(): FluentPick<A> | undefined {
     const value: any = []
     const original: any[] = []
+
     for (const a of this.arbitraries) {
       const pick = a.pick()
       if (pick === undefined) return undefined
@@ -64,4 +65,6 @@ export class ArbitraryTuple<U extends Arbitrary<any>[], A = UnwrapFluentPick<U>>
 
     return true
   }
+
+  toString(depth: number) { return ' '.repeat(2 * depth) + 'Tuple Arbitrary:\n' + this.arbitraries.map(a => a.toString(depth + 1)).join('\n') }
 }

--- a/src/arbitraries/ChainedArbitrary.ts
+++ b/src/arbitraries/ChainedArbitrary.ts
@@ -15,4 +15,6 @@ export class ChainedArbitrary<A, B> extends Arbitrary<B> {
   cornerCases(): FluentPick<B>[] {
     return this.baseArbitrary.cornerCases().flatMap(p => this.f(p.value).cornerCases())
   }
+
+  toString(depth = 0) { return ' '.repeat(depth * 2) + `Chained Arbitrary: f = ${this.f.toString()}\n` + this.baseArbitrary.toString(depth + 1)}
 }

--- a/src/arbitraries/FilteredArbitrary.ts
+++ b/src/arbitraries/FilteredArbitrary.ts
@@ -43,4 +43,6 @@ export class FilteredArbitrary<A> extends WrappedArbitrary<A> {
   canGenerate(pick: FluentPick<A>) {
     return this.baseArbitrary.canGenerate(pick) /* && this.f(pick.value) */
   }
+
+  toString(depth = 0) { return ' '.repeat(depth * 2) + `Filtered Arbitrary: f = ${this.f.toString()}\n` + this.baseArbitrary.toString(depth + 1)}
 }

--- a/src/arbitraries/MappedArbitrary.ts
+++ b/src/arbitraries/MappedArbitrary.ts
@@ -7,7 +7,7 @@ export class MappedArbitrary<A, B> extends Arbitrary<B> {
   }
 
   mapFluentPick(p: FluentPick<A>): FluentPick<B> {
-    const original = ('original' in p) ? p.original : p.value
+    const original = ('original' in p && p.original !== undefined) ? p.original : p.value
     return ({ original, value: this.f(p.value) })
   }
 
@@ -34,4 +34,6 @@ export class MappedArbitrary<A, B> extends Arbitrary<B> {
   canGenerate(pick: FluentPick<B>) {
     return this.baseArbitrary.canGenerate({ value: pick.original, original: pick.original }) /* && pick.value === this.f(pick.original) */
   }
+
+  toString(depth = 0) { return ' '.repeat(2 * depth) + `Map Arbitrary: f = ${this.f.toString()}\n` + this.baseArbitrary.toString(depth + 1) }
 }

--- a/src/arbitraries/NoArbitrary.ts
+++ b/src/arbitraries/NoArbitrary.ts
@@ -10,4 +10,5 @@ export const NoArbitrary: Arbitrary<never> = new class extends Arbitrary<never> 
   unique() { return NoArbitrary }
   canGenerate(_: FluentPick<never>) { return false }
   chain<B>(_: (a: never) => Arbitrary<B>) { return NoArbitrary }
+  toString(depth = 0) { return ' '.repeat(depth * 2) + 'No Arbitrary' }
 }()

--- a/src/arbitraries/UniqueArbitrary.ts
+++ b/src/arbitraries/UniqueArbitrary.ts
@@ -27,4 +27,6 @@ export class UniqueArbitrary<A> extends WrappedArbitrary<A> {
   shrink(initial: FluentPick<A>) {
     return this.baseArbitrary.shrink(initial).unique()
   }
+
+  toString(depth = 0) { return ' '.repeat(depth * 2) + 'Unique Arbitrary:\n' + this.baseArbitrary.toString(depth + 1)}
 }

--- a/src/arbitraries/WrappedArbitrary.ts
+++ b/src/arbitraries/WrappedArbitrary.ts
@@ -13,4 +13,6 @@ export class WrappedArbitrary<A> extends Arbitrary<A> {
   canGenerate(pick: FluentPick<A>) {
     return this.baseArbitrary.canGenerate(pick)
   }
+
+  toString(depth = 0) { return ' '.repeat(depth * 2) + 'Wrapped Arbitrary:\n' + this.baseArbitrary.toString(depth + 1)}
 }


### PR DESCRIPTION
It's now possible to pretty print arbitraries with toString().

Example:

```typescript
fc.tuple(
  fc.integer(50, 1000).filter(x => x > 100),
  fc.string(1, 10, 'a').filter(x => x.length > 2)).map(([a, b]) => [a * 2, '_'.concat(b)])
``` 

Becomes:

```
Map Arbitrary: f = ([a, b]) => [a * 2, '_'.concat(b)]
  Tuple Arbitrary:
    Filtered Arbitrary: f = x => x > 100
      Integer Arbitrary: min = 50 max = 1000
    Filtered Arbitrary: f = x => x.length > 2
      Map Arbitrary: f = a => a.join('')
        Array Arbitrary: min = 1 max = 10
          Map Arbitrary: f = n => chars[n]
            Constant Arbitrary: 0
```

Shrinking, we get:

```
Map Arbitrary: f = v => this.f(v)
  Composite Arbitrary:
    Tuple Arbitrary:
      Filtered Arbitrary: f = v => this.f(v)
        Composite Arbitrary:
          Integer Arbitrary: min = 50 max = 364
          Integer Arbitrary: min = 365 max = 681
      Filtered Arbitrary: f = x => x.length > 2
        Map Arbitrary: f = a => a.join('')
          Array Arbitrary: min = 1 max = 10
            Map Arbitrary: f = n => chars[n]
              Constant Arbitrary: 0
    Tuple Arbitrary:
      Filtered Arbitrary: f = x => x > 100
        Integer Arbitrary: min = 50 max = 1000
      Filtered Arbitrary: f = v => this.f(v)
        Map Arbitrary: f = v => this.f(v)
          Array Arbitrary: min = 1 max = 2
            Map Arbitrary: f = n => chars[n]
              Constant Arbitrary: 0
```