### PR TITLE
Merge duplicated code used in forall and exists.

### DIFF
--- a/src/FluentCheck.ts
+++ b/src/FluentCheck.ts
@@ -164,7 +164,7 @@ abstract class FluentCheckQuantifier<K extends string, A, Rec extends ParentRec 
     partial: FluentResult | undefined = undefined,
     depth = 0): FluentResult {
 
-    const example = partial || new FluentResult(this.defaultValue)
+    const example = partial || new FluentResult(!this.breakCondition)
 
     const collection = depth === 0 ?
       this.cache :
@@ -184,21 +184,16 @@ abstract class FluentCheckQuantifier<K extends string, A, Rec extends ParentRec 
     return example
   }
 
-  abstract defaultValue: boolean
   abstract breakCondition: boolean
 }
 
 class FluentCheckUniversal<K extends string, A, Rec extends ParentRec & Record<K, A>, ParentRec extends {}>
   extends FluentCheckQuantifier<K, A, Rec, ParentRec> {
-
-  defaultValue = true
   breakCondition = false
 }
 
 class FluentCheckExistential<K extends string, A, Rec extends ParentRec & Record<K, A>, ParentRec extends {}>
   extends FluentCheckQuantifier<K, A, Rec, ParentRec> {
-
-  defaultValue = false
   breakCondition = true
 }
 

--- a/src/FluentCheck.ts
+++ b/src/FluentCheck.ts
@@ -175,7 +175,7 @@ abstract class FluentCheckQuantifier<K extends string, A, Rec extends ParentRec 
     for (const tp of collection) {
       testCase[this.name] = tp
       const result = callback(testCase)
-      if (this.breakCondition(result.satisfiable)) {
+      if (result.satisfiable === this.breakCondition) {
         result.addExample(this.name, tp)
         return this.run(testCase, callback, result, depth + 1)
       }
@@ -185,21 +185,21 @@ abstract class FluentCheckQuantifier<K extends string, A, Rec extends ParentRec 
   }
 
   abstract defaultValue: boolean
-  abstract breakCondition: (b: boolean) => boolean
+  abstract breakCondition: boolean
 }
 
 class FluentCheckUniversal<K extends string, A, Rec extends ParentRec & Record<K, A>, ParentRec extends {}>
   extends FluentCheckQuantifier<K, A, Rec, ParentRec> {
 
   defaultValue = true
-  breakCondition = (b => !b)
+  breakCondition = false
 }
 
 class FluentCheckExistential<K extends string, A, Rec extends ParentRec & Record<K, A>, ParentRec extends {}>
   extends FluentCheckQuantifier<K, A, Rec, ParentRec> {
 
   defaultValue = false
-  breakCondition = (b => b)
+  breakCondition = true
 }
 
 class FluentCheckAssert<Rec extends ParentRec, ParentRec extends {}> extends FluentCheck<Rec, ParentRec> {

--- a/src/FluentCheck.ts
+++ b/src/FluentCheck.ts
@@ -164,7 +164,7 @@ abstract class FluentCheckQuantifier<K extends string, A, Rec extends ParentRec 
     partial: FluentResult | undefined = undefined,
     depth = 0): FluentResult {
 
-    const example = partial || new FluentResult(!this.breakCondition)
+    const example = partial || new FluentResult(!this.breakValue)
 
     const collection = depth === 0 ?
       this.cache :
@@ -175,7 +175,7 @@ abstract class FluentCheckQuantifier<K extends string, A, Rec extends ParentRec 
     for (const tp of collection) {
       testCase[this.name] = tp
       const result = callback(testCase)
-      if (result.satisfiable === this.breakCondition) {
+      if (result.satisfiable === this.breakValue) {
         result.addExample(this.name, tp)
         return this.run(testCase, callback, result, depth + 1)
       }
@@ -184,17 +184,17 @@ abstract class FluentCheckQuantifier<K extends string, A, Rec extends ParentRec 
     return example
   }
 
-  abstract breakCondition: boolean
+  abstract breakValue: boolean
 }
 
 class FluentCheckUniversal<K extends string, A, Rec extends ParentRec & Record<K, A>, ParentRec extends {}>
   extends FluentCheckQuantifier<K, A, Rec, ParentRec> {
-  breakCondition = false
+  breakValue = false
 }
 
 class FluentCheckExistential<K extends string, A, Rec extends ParentRec & Record<K, A>, ParentRec extends {}>
   extends FluentCheckQuantifier<K, A, Rec, ParentRec> {
-  breakCondition = true
+  breakValue = true
 }
 
 class FluentCheckAssert<Rec extends ParentRec, ParentRec extends {}> extends FluentCheck<Rec, ParentRec> {


### PR DESCRIPTION
A lot of code in `FluentCheckUniversal` and `FluentCheckExistential` was basically the same. Abstracted that away in `FluentCheckQuantifier`.