### PR TITLE
Simplified Shrink in ArbitraryTuple

### DIFF
--- a/src/arbitraries/ArbitraryTuple.ts
+++ b/src/arbitraries/ArbitraryTuple.ts
@@ -4,7 +4,7 @@ import * as fc from './index'
 
 type UnwrapFluentPick<T> = { [P in keyof T]: T[P] extends fc.Arbitrary<infer E> ? E : T[P] }
 
-export class ArbitraryTuple<U extends Arbitrary<any>[], A = UnwrapFluentPick<U>> extends Arbitrary<A> {
+export class ArbitraryTuple<U extends readonly Arbitrary<any>[], A = UnwrapFluentPick<U>> extends Arbitrary<A> {
   constructor(public readonly arbitraries: U) {
     super()
   }
@@ -48,15 +48,12 @@ export class ArbitraryTuple<U extends Arbitrary<any>[], A = UnwrapFluentPick<U>>
   }
 
   shrink<B extends A>(initial: FluentPick<B>): Arbitrary<A> {
-    const tuples = this.arbitraries.map(selected =>
-      this.arbitraries.map((arbitrary, i) =>
-        (arbitrary === selected) ?
+    return fc.union(...this.arbitraries.map((_, selected) =>
+      fc.tuple(...this.arbitraries.map((arbitrary, i) =>
+        (selected === i) ?
           arbitrary.shrink({value: initial.value[i], original: initial.original[i]}) :
           fc.constant(initial.value[i])
-      )
-    ).filter(t => t.every(a => a !== NoArbitrary))
-
-    return fc.union(...tuples.map(t => fc.tuple(...t))) as unknown as Arbitrary<A>
+      )))) as unknown as Arbitrary<A>
   }
 
   canGenerate<B extends A>(pick: FluentPick<B>): boolean {


### PR DESCRIPTION
This is just another step in simplifying the shrink logic of `ArbitraryTuple` after 5467ce8. 

By the way, is anyone brave enough to put some sanity in the types of this class? Typescript [supports variadic tuple types](https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/#variadic-tuple-types) ever since v4.0, but we are clearly not using them correctly, and so we have a lot of unsafe casting going around.