### PR TITLE
Fixing ArbitraryInteger shrinking problem

### DIFF
--- a/src/arbitraries/ArbitraryInteger.ts
+++ b/src/arbitraries/ArbitraryInteger.ts
@@ -28,14 +28,14 @@ export class ArbitraryInteger extends Arbitrary<number> {
       const lower = Math.max(0, this.min)
       const upper = Math.max(lower, initial.value - 1)
 
-      if (lower === upper) return NoArbitrary
+      if (lower === upper && initial.value !== 1) return NoArbitrary
 
       return fc.integer(lower, upper)
     } else if (initial.value < 0) {
       const upper = Math.min(0, this.max)
       const lower = Math.min(upper, initial.value + 1)
 
-      if (lower === upper) return NoArbitrary
+      if (lower === upper && initial.value !== -1) return NoArbitrary
 
       return fc.integer(lower, upper)
     }

--- a/src/arbitraries/ArbitraryInteger.ts
+++ b/src/arbitraries/ArbitraryInteger.ts
@@ -26,16 +26,16 @@ export class ArbitraryInteger extends Arbitrary<number> {
   shrink(initial: FluentPick<number>): Arbitrary<number> {
     if (initial.value > 0) {
       const lower = Math.max(0, this.min)
-      const upper = Math.max(lower, initial.value - 1)
+      const upper = initial.value - 1
 
-      if (lower === upper && initial.value !== 1) return NoArbitrary
+      if (upper < lower) return NoArbitrary
 
       return fc.integer(lower, upper)
     } else if (initial.value < 0) {
       const upper = Math.min(0, this.max)
-      const lower = Math.min(upper, initial.value + 1)
+      const lower = initial.value + 1
 
-      if (lower === upper && initial.value !== -1) return NoArbitrary
+      if (lower > upper) return NoArbitrary
 
       return fc.integer(lower, upper)
     }

--- a/test/integers.test.ts
+++ b/test/integers.test.ts
@@ -57,6 +57,12 @@ describe('Integer tests', () => {
 
   it('finds that adding 1000 makes any number larger and shrinks the example', () => {
     expect(fc.scenario()
+      .config(fc.strategy()
+        .withRandomSampling()
+        .usingCache()
+        .withoutReplacement()
+        .withShrinking()
+      )
       .exists('a', fc.integer())
       .then(({a}) => a + 1000 > a)
       .check()


### PR DESCRIPTION
The current version of the ArbitraryIntegers shrinking process is not working properly because it does not allow shrinking an integer to its neutral value `0`. The integers' test suite version on the `master` branch only succeeds because the current default strategy considers bias and `0` belongs to the set of corner cases.