### PR TITLE
Minor safety issues with "truthy" operators

### DIFF
--- a/src/FluentCheck.ts
+++ b/src/FluentCheck.ts
@@ -178,7 +178,7 @@ abstract class FluentCheckQuantifier<K extends string, A, Rec extends ParentRec 
       }
     }
 
-    return partial || new FluentResult(!this.breakValue)
+    return partial ?? new FluentResult(!this.breakValue)
   }
 
   abstract breakValue: boolean

--- a/src/arbitraries/MappedArbitrary.ts
+++ b/src/arbitraries/MappedArbitrary.ts
@@ -13,7 +13,7 @@ export class MappedArbitrary<A, B> extends Arbitrary<B> {
 
   pick(): FluentPick<B> | undefined {
     const pick = this.baseArbitrary.pick()
-    return pick ? this.mapFluentPick(pick) : undefined
+    return pick !== undefined ? this.mapFluentPick(pick) : undefined
   }
 
   // TODO: This is not strictly true when the mapping function is not bijective. I suppose this is


### PR DESCRIPTION
Replace two unsafe usages of "truthy" and || with explicit comparison with undefined and ??.