### PR TITLE
docs: add spec deltas to TypeScript modernization proposals

### DIFF
--- a/openspec/changes/ts-modernise-const-type-params/specs/arbitraries/spec.md
+++ b/openspec/changes/ts-modernise-const-type-params/specs/arbitraries/spec.md
@@ -1,0 +1,44 @@
+# Arbitraries
+
+## MODIFIED Requirements
+
+### Requirement: OneOf Combinator
+
+The system SHALL provide an `oneof(elements)` function that generates one of the given values, preserving literal types when called with literal arrays.
+
+#### Scenario: Generate from set
+- **WHEN** `fc.oneof(['a', 'b', 'c'])` is called
+- **THEN** one of 'a', 'b', or 'c' is generated each time
+
+#### Scenario: Empty array
+- **WHEN** `fc.oneof([])` is called
+- **THEN** NoArbitrary SHALL be returned
+
+#### Scenario: Literal type preservation
+- **WHEN** `fc.oneof(['pending', 'active', 'done'])` is called with literal values
+- **THEN** the inferred type SHALL be `Arbitrary<'pending' | 'active' | 'done'>`
+- **AND** exhaustive switch statements on generated values SHALL be type-safe
+
+### Requirement: Set Arbitrary
+
+The system SHALL provide a `set(elements, min?, max?)` function that creates subsets of the given elements, preserving literal types when called with literal arrays.
+
+#### Scenario: Generate subsets
+- **WHEN** `fc.set([1, 2, 3, 4, 5], 2, 3)` is called
+- **THEN** arrays of 2-3 unique elements from the input are generated
+
+#### Scenario: Literal type preservation
+- **WHEN** `fc.set(['red', 'green', 'blue'], 1, 2)` is called with literal values
+- **THEN** the inferred type SHALL be `Arbitrary<('red' | 'green' | 'blue')[]>`
+
+### Requirement: Tuple Arbitrary
+
+The system SHALL provide a `tuple(...arbitraries)` function that creates tuples of generated values with strict tuple type inference.
+
+#### Scenario: Generate typed tuples
+- **WHEN** `fc.tuple(fc.integer(), fc.string(), fc.boolean())` is called
+- **THEN** tuples of type `[number, string, boolean]` are generated
+
+#### Scenario: Strict tuple inference
+- **WHEN** arbitrary combinators are composed with `tuple()`
+- **THEN** TypeScript SHALL infer exact tuple types in all contexts

--- a/openspec/changes/ts-modernise-discriminated-unions/specs/arbitraries/spec.md
+++ b/openspec/changes/ts-modernise-discriminated-unions/specs/arbitraries/spec.md
@@ -1,0 +1,27 @@
+# Arbitraries
+
+## MODIFIED Requirements
+
+### Requirement: Size Estimation
+
+The system SHALL provide size information for arbitraries using a discriminated union type for exact and estimated sizes.
+
+#### Scenario: Exact size
+- **WHEN** `fc.integer(0, 10).size()` is called
+- **THEN** an exact size with value 11 is returned
+- **AND** the returned type SHALL be `ExactSize` with only `type` and `value` fields
+
+#### Scenario: Estimated size
+- **WHEN** a filtered arbitrary's size is queried
+- **THEN** an estimated size with credible interval is returned
+- **AND** the returned type SHALL be `EstimatedSize` with `type`, `value`, and `credibleInterval` fields
+
+#### Scenario: Discriminated union type narrowing
+- **WHEN** code checks `size.type === 'exact'`
+- **THEN** TypeScript SHALL narrow the type to exclude `credibleInterval` field access
+- **AND** exhaustive switch statements on `size.type` SHALL be type-safe
+
+#### Scenario: Factory functions for size creation
+- **WHEN** creating size values programmatically
+- **THEN** `exactSize(value)` SHALL return an `ExactSize` object
+- **AND** `estimatedSize(value, interval)` SHALL return an `EstimatedSize` object

--- a/openspec/changes/ts-modernise-import-type/specs/tooling/spec.md
+++ b/openspec/changes/ts-modernise-import-type/specs/tooling/spec.md
@@ -1,0 +1,20 @@
+# Tooling
+
+## ADDED Requirements
+
+### Requirement: Type-Only Import Syntax
+
+The codebase SHALL use explicit `import type` syntax for imports that are only used for type annotations.
+
+#### Scenario: Type-only imports marked explicitly
+- **WHEN** a module imports symbols used only as types
+- **THEN** the import SHALL use `import type { ... }` syntax
+
+#### Scenario: Mixed imports use inline type modifier
+- **WHEN** a module imports both runtime values and type-only symbols
+- **THEN** the import SHALL use inline `type` modifier: `import { value, type TypeOnly } from '...'`
+
+#### Scenario: Bundler tree-shaking optimization
+- **WHEN** the codebase is bundled
+- **THEN** type-only imports SHALL be completely elided from the output
+- **AND** no runtime dependencies on type-only modules SHALL exist

--- a/openspec/changes/ts-modernise-noinfer/specs/fluent-api/spec.md
+++ b/openspec/changes/ts-modernise-noinfer/specs/fluent-api/spec.md
@@ -1,0 +1,41 @@
+# Fluent API
+
+## MODIFIED Requirements
+
+### Requirement: Given Clause
+
+The system SHALL provide a `given(name, valueOrFactory)` method for setting up derived values or constants before assertions, with controlled type inference from factory functions.
+
+#### Scenario: Given with constant value
+- **WHEN** `.given('c', 42)` is called
+- **THEN** the constant value is available as `c` in subsequent methods
+
+#### Scenario: Given with factory function
+- **WHEN** `.given('sum', ({x, y}) => x + y)` is called
+- **THEN** the factory is evaluated for each test case
+- **AND** the result is available as `sum`
+
+#### Scenario: Chained given clauses
+- **WHEN** `.given('a', 1).and('b', ({a}) => a + 1)` is called
+- **THEN** `b` can reference the value of `a`
+
+#### Scenario: Type inference from factory return
+- **WHEN** both constant and factory positions could infer a type parameter
+- **THEN** the factory return type SHALL be the primary inference source
+- **AND** type errors SHALL point to the factory function location
+
+### Requirement: Then Clause (Assertion)
+
+The system SHALL provide a `then(predicate)` method that defines the property to be tested.
+
+#### Scenario: Define property assertion
+- **WHEN** `.then(({x, y}) => x + y === y + x)` is called
+- **THEN** the predicate is evaluated for each generated test case
+
+#### Scenario: Chained assertions
+- **WHEN** `.then(predicate1).and(predicate2)` is called
+- **THEN** both predicates must hold for the property to pass
+
+#### Scenario: And clause type inference
+- **WHEN** `.and(name, valueOrFactory)` is used after `.then()`
+- **THEN** the factory return type SHALL be the primary inference source for type parameter `V`

--- a/openspec/changes/ts-modernise-override/specs/tooling/spec.md
+++ b/openspec/changes/ts-modernise-override/specs/tooling/spec.md
@@ -1,0 +1,21 @@
+# Tooling
+
+## ADDED Requirements
+
+### Requirement: Explicit Override Keyword
+
+All methods that override parent class methods SHALL use the explicit `override` keyword.
+
+#### Scenario: Override keyword on subclass methods
+- **WHEN** a class method overrides a parent method
+- **THEN** the method SHALL be marked with the `override` keyword
+
+#### Scenario: Compiler enforcement enabled
+- **WHEN** `noImplicitOverride: true` is set in tsconfig
+- **THEN** TypeScript SHALL error if `override` keyword is missing on overriding methods
+- **AND** TypeScript SHALL error if `override` is used on non-overriding methods
+
+#### Scenario: Safe refactoring of parent classes
+- **WHEN** a parent method is renamed or removed
+- **THEN** the compiler SHALL error on child classes with stale `override` declarations
+- **AND** accidental method shadowing SHALL be prevented

--- a/openspec/changes/ts-modernise-private-fields/specs/tooling/spec.md
+++ b/openspec/changes/ts-modernise-private-fields/specs/tooling/spec.md
@@ -1,0 +1,22 @@
+# Tooling
+
+## ADDED Requirements
+
+### Requirement: Native Private Fields
+
+Class fields requiring true runtime privacy SHALL use ES2022 native private fields (`#field`) instead of TypeScript's `private` keyword.
+
+#### Scenario: Private field syntax
+- **WHEN** a class field requires encapsulation
+- **THEN** the field SHALL use `#` prefix syntax
+- **AND** internal references SHALL use `this.#field` syntax
+
+#### Scenario: Runtime privacy enforcement
+- **WHEN** external code attempts to access private fields
+- **THEN** access SHALL be blocked at runtime (not just compile-time)
+- **AND** type assertions SHALL not bypass privacy
+
+#### Scenario: TypeScript private for protected-like access
+- **WHEN** subclass access to a parent field is required
+- **THEN** the TypeScript `private` keyword MAY be retained
+- **AND** the design decision SHALL be documented in code comments

--- a/openspec/changes/ts-modernise-reduce-type-assertions/specs/tooling/spec.md
+++ b/openspec/changes/ts-modernise-reduce-type-assertions/specs/tooling/spec.md
@@ -1,0 +1,26 @@
+# Tooling
+
+## ADDED Requirements
+
+### Requirement: Minimal Type Assertions
+
+The codebase SHALL minimize use of `as unknown as T` type assertions by leveraging proper type system patterns.
+
+#### Scenario: No unnecessary assertions in factory functions
+- **WHEN** arbitrary factory functions return concrete types
+- **THEN** TypeScript SHALL accept the types without `as unknown as` assertions
+- **AND** type inference SHALL correctly unify return types
+
+#### Scenario: Strict mode enabled
+- **WHEN** `strict: true` is enabled in tsconfig
+- **THEN** hidden type errors SHALL be surfaced
+- **AND** necessary fixes SHALL be applied to satisfy strict checks
+
+#### Scenario: NoArbitrary type compatibility
+- **WHEN** `NoArbitrary` (typed as `Arbitrary<never>`) is returned from factory functions
+- **THEN** the return type SHALL unify correctly with concrete arbitrary types
+- **AND** no type assertions SHALL be required for ternary expressions
+
+#### Scenario: ESLint assertion warning
+- **WHEN** unnecessary type assertions remain in the codebase
+- **THEN** `@typescript-eslint/no-unnecessary-type-assertion` MAY flag them

--- a/openspec/changes/ts-modernise-satisfies/specs/arbitraries/spec.md
+++ b/openspec/changes/ts-modernise-satisfies/specs/arbitraries/spec.md
@@ -1,0 +1,28 @@
+# Arbitraries
+
+## MODIFIED Requirements
+
+### Requirement: Pattern Generators
+
+The system SHALL provide pre-built generators for common patterns via `fc.patterns`, with literal key types preserved for type-safe access.
+
+#### Scenario: email pattern
+- **WHEN** `fc.patterns.email()` is called
+- **THEN** valid email address strings are generated
+
+#### Scenario: uuid pattern
+- **WHEN** `fc.patterns.uuid()` is called
+- **THEN** valid UUID v4 strings are generated
+
+#### Scenario: ipv4 pattern
+- **WHEN** `fc.patterns.ipv4()` is called
+- **THEN** valid IPv4 address strings are generated
+
+#### Scenario: url pattern
+- **WHEN** `fc.patterns.url()` is called
+- **THEN** valid URL strings are generated
+
+#### Scenario: Pattern key type inference
+- **WHEN** `keyof typeof fc.patterns` is evaluated
+- **THEN** the type SHALL be a union of literal strings (`'email' | 'uuid' | 'ipv4' | 'url'`)
+- **AND** consumers SHALL be able to iterate pattern names type-safely

--- a/openspec/changes/ts-modernise-strict-mode/specs/tooling/spec.md
+++ b/openspec/changes/ts-modernise-strict-mode/specs/tooling/spec.md
@@ -1,0 +1,27 @@
+# Tooling
+
+## ADDED Requirements
+
+### Requirement: Full TypeScript Strict Mode
+
+The project SHALL enable full TypeScript strict mode for maximum type safety.
+
+#### Scenario: Strict mode enabled
+- **WHEN** TypeScript compiles the project
+- **THEN** `strict: true` SHALL be set in tsconfig.json
+- **AND** all individual strict flags SHALL be implicitly enabled
+
+#### Scenario: Unchecked index access protection
+- **WHEN** `noUncheckedIndexedAccess: true` is enabled
+- **THEN** array/object index access SHALL return `T | undefined`
+- **AND** code SHALL handle potential undefined values explicitly
+
+#### Scenario: Exact optional property types
+- **WHEN** `exactOptionalPropertyTypes: true` is enabled
+- **THEN** TypeScript SHALL distinguish between `undefined` values and missing properties
+- **AND** explicit `undefined` assignment to optional properties SHALL require the type to include `undefined`
+
+#### Scenario: Property access from index signatures
+- **WHEN** `noPropertyAccessFromIndexSignature: true` is enabled
+- **THEN** bracket notation SHALL be required for index signature access
+- **AND** dot notation SHALL only work for explicitly declared properties


### PR DESCRIPTION
## Summary

- Add missing spec delta files to 9 TypeScript modernization change proposals
- All proposals now pass `openspec validate --strict`
- Specs categorized by user-facing type improvements vs internal tooling changes

## Changes

**User-facing type improvements (arbitraries/fluent-api specs):**
- `ts-modernise-const-type-params`: literal type preservation for `oneof`, `set`, `tuple`
- `ts-modernise-discriminated-unions`: `ArbitrarySize` discriminated union types
- `ts-modernise-satisfies`: pattern key type inference
- `ts-modernise-noinfer`: controlled type inference for `given`, `and`

**Internal/tooling improvements (tooling spec):**
- `ts-modernise-import-type`: type-only import syntax
- `ts-modernise-override`: explicit override keyword
- `ts-modernise-private-fields`: native ES2022 private fields
- `ts-modernise-reduce-type-assertions`: minimal type assertions
- `ts-modernise-strict-mode`: full TypeScript strict mode

## Test Plan

- [x] All 9 spec files created with proper ADDED/MODIFIED Requirements format
- [x] All changes pass `openspec validate <change-id> --strict`
- [x] Existing changes (`profile-performance-hotspots`, `research-fluent-api-ergonomics`) still valid