### PR TITLE
docs: add InvalidArbitrary proposal for configuration error handling

### DIFF
--- a/openspec/changes/add-arbitrary-validation/proposal.md
+++ b/openspec/changes/add-arbitrary-validation/proposal.md
@@ -1,4 +1,4 @@
-# Change: Add Arbitrary Validation with Fail-Fast Error Handling
+# Change: Add InvalidArbitrary for Configuration Error Handling
 
 > **GitHub Issue:** [#118](https://github.com/fluent-check/fluent-check/issues/118)
 
@@ -13,35 +13,97 @@ As discussed in issue #118, there are different levels of "invalid":
 
 The current implementation handles case 3 correctly but silently degrades cases 1 and 2 to `NoArbitrary`, which can mask configuration errors in tests.
 
+### Why Not Throw Exceptions?
+
+The framework is built on **type safety and functional composition**, not runtime exceptions. Throwing at construction time:
+- Breaks compositional nature of arbitraries
+- Feels un-functional and surprising
+- Prevents building up complex arbitraries that might only become invalid in certain contexts
+
 ## What Changes
 
-### Public API Validation
-- **BREAKING**: `fc.integer(min, max)` SHALL throw `RangeError` when `min > max`
-- **BREAKING**: `fc.real(min, max)` SHALL throw `RangeError` when `min > max`
-- **BREAKING**: `fc.nat(min, max)` SHALL throw `RangeError` when `max < 0`
-- **BREAKING**: `fc.array(arb, min, max)` SHALL throw `RangeError` when `min > max` or `min < 0`
-- **BREAKING**: `fc.set(elements, min, max)` SHALL throw `RangeError` when `min > max`, `min < 0`, or `min > elements.length`
-- **BREAKING**: `fc.oneof(elements)` SHALL throw `RangeError` when `elements` is empty
+### New Type: `InvalidArbitrary<Reason>`
 
-### Internal Unsafe Variants
-- Add `{ unsafe: true }` option parameter to factory functions
-- When `unsafe: true`, return `NoArbitrary` instead of throwing (for shrinking)
-- Update all `shrink()` methods to use `unsafe: true`
+Introduce a third type distinct from `NoArbitrary`:
 
-### Warning Mode (Optional Enhancement)
-- Add optional `fc.configure({ warnOnEmpty: true })` to emit warnings when `NoArbitrary` is used in propositions
-- Helps detect vacuous truth scenarios without breaking execution
+| Type | Meaning | Source | Test Result |
+|------|---------|--------|-------------|
+| `NoArbitrary` | Legitimate empty set | Internal (shrinking exhausted, filter eliminated all) | Pass (vacuously true) |
+| `InvalidArbitrary<R>` | Configuration error | User API misuse | **Fail** with diagnostic |
+
+```typescript
+// New type that carries error context but behaves like an empty arbitrary
+export interface InvalidArbitrary<R extends string = string> extends Arbitrary<never> {
+  readonly _tag: 'invalid'
+  readonly reason: R
+}
+
+export const InvalidArbitrary = <R extends string>(reason: R): InvalidArbitrary<R> => 
+  new class extends Arbitrary<never> {
+    readonly _tag = 'invalid' as const
+    readonly reason = reason
+    
+    pick(): undefined { return undefined }
+    size(): ArbitrarySize { return { value: 0, type: 'exact', credibleInterval: [0, 0] } }
+    // ... same runtime behavior as NoArbitrary
+  }()
+```
+
+### Public API Changes
+
+- `fc.integer(min, max)` SHALL return `InvalidArbitrary` when `min > max`
+- `fc.real(min, max)` SHALL return `InvalidArbitrary` when `min > max`
+- `fc.nat(min, max)` SHALL return `InvalidArbitrary` when `max < 0`
+- `fc.array(arb, min, max)` SHALL return `InvalidArbitrary` when `min > max` or `min < 0`
+- `fc.set(elements, min, max)` SHALL return `InvalidArbitrary` when `min > max`, `min < 0`, or `min > elements.length`
+- `fc.oneof(elements)` SHALL return `InvalidArbitrary` when `elements` is empty
+
+### Internal Behavior Unchanged
+
+- `shrink()` methods continue to return `NoArbitrary` for legitimate empty ranges
+- `filter()` continues to return `NoArbitrary` when all values filtered out
+- No changes to shrinking algorithm
+
+### FluentCheck Runner Changes
+
+The runner detects `InvalidArbitrary` during property evaluation:
+
+```typescript
+// FluentCheck.ts - during property evaluation
+private evaluateProperty<T>(arb: Arbitrary<T>): PropertyResult {
+  if (isInvalidArbitrary(arb)) {
+    return { 
+      status: 'invalid',  // distinct from 'pass' | 'fail'
+      reason: arb.reason,
+      suggestion: 'Check your arbitrary configuration'
+    }
+  }
+  // ... normal evaluation
+}
+```
+
+Output:
+```
+✗ Property "user ages are positive" - INVALID CONFIGURATION
+  → integer: min (10) exceeds max (5)
+```
 
 ## Impact
 
-- **Affected specs**: `arbitraries`
-- **Affected code**: `src/arbitraries/index.ts`, all arbitrary classes with `shrink()` methods
-- **Breaking**: Yes - code relying on silent `NoArbitrary` return will now throw
-- **Migration**: Users must fix invalid arbitrary configurations or explicitly use `fc.empty()`
+- **Affected specs**: `arbitraries`, `reporting`
+- **Affected code**: 
+  - `src/arbitraries/InvalidArbitrary.ts` (new file)
+  - `src/arbitraries/index.ts` (factory functions)
+  - `src/FluentCheck.ts` (runner detection)
+  - `src/FluentReporter.ts` (output formatting)
+- **Breaking**: Behavioral - invalid configurations that previously passed silently will now fail
+- **Migration**: Users must fix invalid arbitrary configurations (the correct fix for their bug)
 
 ## Rationale
 
-1. **Fail-fast principle**: Configuration errors should surface immediately, not produce mysterious test results
-2. **Preserve shrinking**: Internal shrinking operations naturally narrow ranges and must not throw
-3. **Explicit intent**: Users who want empty arbitraries can use `fc.empty()` explicitly
-4. **IDE analogy**: Similar to IDE warnings for always-true/false conditions - catches logic errors early
+1. **Preserves composition**: No exceptions during construction, arbitraries compose freely
+2. **Semantic distinction**: Clear difference between "legitimately empty" and "configuration error"
+3. **Actionable feedback**: Error messages explain what's wrong and how to fix it
+4. **No silent pass**: Invalid configurations fail tests, surfacing bugs early
+5. **Shrinking unaffected**: Internal `NoArbitrary` usage continues to work correctly
+6. **Type-safe philosophy**: Aligns with framework's emphasis on types over runtime checks

--- a/openspec/changes/add-arbitrary-validation/specs/arbitraries/spec.md
+++ b/openspec/changes/add-arbitrary-validation/specs/arbitraries/spec.md
@@ -1,10 +1,51 @@
 # Arbitraries Delta
 
+## ADDED Requirements
+
+### Requirement: InvalidArbitrary Type
+
+The system SHALL provide an `InvalidArbitrary<Reason>` type representing a configuration error in arbitrary construction.
+
+#### Scenario: InvalidArbitrary structure
+- **WHEN** an `InvalidArbitrary` is created
+- **THEN** it SHALL have a `_tag` property equal to `'invalid'`
+- **AND** it SHALL have a `reason` property containing the error description
+
+#### Scenario: InvalidArbitrary behavior
+- **WHEN** methods are called on an `InvalidArbitrary`
+- **THEN** `pick()` SHALL return `undefined`
+- **AND** `size()` SHALL return `{ value: 0, type: 'exact', credibleInterval: [0, 0] }`
+- **AND** `sample()` SHALL return an empty array
+- **AND** `map()` SHALL return `InvalidArbitrary` with same reason
+- **AND** `filter()` SHALL return `InvalidArbitrary` with same reason
+- **AND** `chain()` SHALL return `InvalidArbitrary` with same reason
+
+#### Scenario: Type guard
+- **WHEN** `isInvalidArbitrary(arb)` is called
+- **THEN** it SHALL return `true` if `arb._tag === 'invalid'`
+- **AND** it SHALL narrow the type to `InvalidArbitrary`
+
+### Requirement: InvalidArbitrary vs NoArbitrary Distinction
+
+The system SHALL distinguish between legitimate empty sets and configuration errors.
+
+#### Scenario: NoArbitrary for shrinking
+- **WHEN** a shrink operation exhausts all possibilities
+- **THEN** `NoArbitrary` SHALL be returned (not `InvalidArbitrary`)
+
+#### Scenario: NoArbitrary for filters
+- **WHEN** a filter eliminates all values from an arbitrary
+- **THEN** `NoArbitrary` SHALL be returned (not `InvalidArbitrary`)
+
+#### Scenario: InvalidArbitrary for user errors
+- **WHEN** a public API factory function receives invalid configuration
+- **THEN** `InvalidArbitrary` SHALL be returned with descriptive reason
+
 ## MODIFIED Requirements
 
 ### Requirement: Integer Arbitrary
 
-The system SHALL provide an `integer(min?, max?, options?)` function that creates an arbitrary generating integers within a range.
+The system SHALL provide an `integer(min?, max?)` function that creates an arbitrary generating integers within a range.
 
 #### Scenario: Generate bounded integers
 - **WHEN** `fc.integer(0, 100)` is called
@@ -14,13 +55,9 @@ The system SHALL provide an `integer(min?, max?, options?)` function that create
 - **WHEN** `fc.integer()` is called without arguments
 - **THEN** the range defaults to [MIN_SAFE_INTEGER, MAX_SAFE_INTEGER]
 
-#### Scenario: Invalid range throws
+#### Scenario: Invalid range returns InvalidArbitrary
 - **WHEN** `fc.integer(10, 5)` is called (min > max)
-- **THEN** a RangeError SHALL be thrown with message indicating invalid range
-
-#### Scenario: Invalid range with unsafe option
-- **WHEN** `fc.integer(10, 5, { unsafe: true })` is called
-- **THEN** NoArbitrary SHALL be returned
+- **THEN** `InvalidArbitrary` SHALL be returned with reason `"integer: min (10) exceeds max (5)"`
 
 #### Scenario: Single value
 - **WHEN** `fc.integer(5, 5)` is called (min === max)
@@ -28,35 +65,27 @@ The system SHALL provide an `integer(min?, max?, options?)` function that create
 
 ### Requirement: Real Arbitrary
 
-The system SHALL provide a `real(min?, max?, options?)` function that creates an arbitrary generating real numbers within a range.
+The system SHALL provide a `real(min?, max?)` function that creates an arbitrary generating real numbers within a range.
 
 #### Scenario: Generate bounded reals
 - **WHEN** `fc.real(-1.0, 1.0)` is called
 - **THEN** all generated values SHALL be real numbers in [-1.0, 1.0]
 
-#### Scenario: Invalid range throws
+#### Scenario: Invalid range returns InvalidArbitrary
 - **WHEN** `fc.real(10.0, 5.0)` is called (min > max)
-- **THEN** a RangeError SHALL be thrown with message indicating invalid range
-
-#### Scenario: Invalid range with unsafe option
-- **WHEN** `fc.real(10.0, 5.0, { unsafe: true })` is called
-- **THEN** NoArbitrary SHALL be returned
+- **THEN** `InvalidArbitrary` SHALL be returned with reason `"real: min (10) exceeds max (5)"`
 
 ### Requirement: Natural Number Arbitrary
 
-The system SHALL provide a `nat(min?, max?, options?)` function that creates an arbitrary generating non-negative integers.
+The system SHALL provide a `nat(min?, max?)` function that creates an arbitrary generating non-negative integers.
 
 #### Scenario: Generate natural numbers
 - **WHEN** `fc.nat()` is called
 - **THEN** all generated values SHALL be >= 0
 
-#### Scenario: Negative max throws
+#### Scenario: Negative max returns InvalidArbitrary
 - **WHEN** `fc.nat(0, -5)` is called
-- **THEN** a RangeError SHALL be thrown with message indicating invalid range
-
-#### Scenario: Negative max with unsafe option
-- **WHEN** `fc.nat(0, -5, { unsafe: true })` is called
-- **THEN** NoArbitrary SHALL be returned
+- **THEN** `InvalidArbitrary` SHALL be returned with reason `"nat: max (-5) must be non-negative"`
 
 #### Scenario: Negative min clamped
 - **WHEN** `fc.nat(-10, 100)` is called
@@ -64,74 +93,62 @@ The system SHALL provide a `nat(min?, max?, options?)` function that creates an 
 
 ### Requirement: Array Arbitrary
 
-The system SHALL provide an `array(arbitrary, min?, max?, options?)` function that creates arrays of generated values.
+The system SHALL provide an `array(arbitrary, min?, max?)` function that creates arrays of generated values.
 
 #### Scenario: Generate bounded arrays
 - **WHEN** `fc.array(fc.integer(), 1, 5)` is called
 - **THEN** arrays of 1-5 integers are generated
 
-#### Scenario: Invalid range throws
+#### Scenario: Invalid range returns InvalidArbitrary
 - **WHEN** `fc.array(fc.integer(), 5, 1)` is called (min > max)
-- **THEN** a RangeError SHALL be thrown with message indicating invalid range
+- **THEN** `InvalidArbitrary` SHALL be returned with reason `"array: minLength (5) exceeds maxLength (1)"`
 
-#### Scenario: Negative min throws
+#### Scenario: Negative min returns InvalidArbitrary
 - **WHEN** `fc.array(fc.integer(), -1, 5)` is called
-- **THEN** a RangeError SHALL be thrown with message indicating invalid bounds
-
-#### Scenario: Invalid range with unsafe option
-- **WHEN** `fc.array(fc.integer(), 5, 1, { unsafe: true })` is called
-- **THEN** NoArbitrary SHALL be returned
+- **THEN** `InvalidArbitrary` SHALL be returned with reason `"array: minLength (-1) must be non-negative"`
 
 ### Requirement: Set Arbitrary
 
-The system SHALL provide a `set(elements, min?, max?, options?)` function that creates subsets of the given elements.
+The system SHALL provide a `set(elements, min?, max?)` function that creates subsets of the given elements.
 
 #### Scenario: Generate subsets
 - **WHEN** `fc.set([1, 2, 3, 4, 5], 2, 3)` is called
 - **THEN** arrays of 2-3 unique elements from the input are generated
 
-#### Scenario: Invalid range throws
+#### Scenario: Invalid range returns InvalidArbitrary
 - **WHEN** `fc.set([1, 2, 3], 5, 1)` is called (min > max)
-- **THEN** a RangeError SHALL be thrown with message indicating invalid range
+- **THEN** `InvalidArbitrary` SHALL be returned with reason `"set: min (5) exceeds max (1)"`
 
-#### Scenario: Min exceeds elements throws
+#### Scenario: Min exceeds elements returns InvalidArbitrary
 - **WHEN** `fc.set([1, 2], 5, 10)` is called (min > elements.length)
-- **THEN** a RangeError SHALL be thrown with message indicating min exceeds available elements
-
-#### Scenario: Invalid bounds with unsafe option
-- **WHEN** `fc.set([1, 2, 3], 5, 1, { unsafe: true })` is called
-- **THEN** NoArbitrary SHALL be returned
+- **THEN** `InvalidArbitrary` SHALL be returned with reason `"set: min (5) exceeds available elements (2)"`
 
 ### Requirement: OneOf Combinator
 
-The system SHALL provide an `oneof(elements, options?)` function that generates one of the given values.
+The system SHALL provide an `oneof(elements)` function that generates one of the given values.
 
 #### Scenario: Generate from set
 - **WHEN** `fc.oneof(['a', 'b', 'c'])` is called
 - **THEN** one of 'a', 'b', or 'c' is generated each time
 
-#### Scenario: Empty array throws
+#### Scenario: Empty array returns InvalidArbitrary
 - **WHEN** `fc.oneof([])` is called
-- **THEN** a RangeError SHALL be thrown with message indicating empty elements array
+- **THEN** `InvalidArbitrary` SHALL be returned with reason `"oneof: elements array is empty"`
 
-#### Scenario: Empty array with unsafe option
-- **WHEN** `fc.oneof([], { unsafe: true })` is called
-- **THEN** NoArbitrary SHALL be returned
+### Requirement: FluentCheck Runner
 
-## ADDED Requirements
+The system SHALL detect and report `InvalidArbitrary` during property evaluation.
 
-### Requirement: Arbitrary Options
+#### Scenario: InvalidArbitrary in property
+- **WHEN** a property uses an `InvalidArbitrary`
+- **THEN** the property result SHALL have status `'invalid'`
+- **AND** the result SHALL include the reason from `InvalidArbitrary`
 
-The system SHALL support an options parameter for arbitrary factory functions to control validation behavior.
+#### Scenario: InvalidArbitrary in composed arbitrary
+- **WHEN** a property uses a composed arbitrary (tuple, chain) containing `InvalidArbitrary`
+- **THEN** the property result SHALL have status `'invalid'`
 
-#### Scenario: Unsafe option type
-- **WHEN** an arbitrary factory is called with `{ unsafe: true }`
-- **THEN** invalid inputs SHALL return NoArbitrary instead of throwing
-
-#### Scenario: Default behavior is safe
-- **WHEN** an arbitrary factory is called without options or with `{ unsafe: false }`
-- **THEN** invalid inputs SHALL throw RangeError
-
-#### Scenario: Shrinking uses unsafe mode
-- **WHEN** an arbitrary's `shrink()` method calls factory functions internally
-- **THEN** it SHALL use `{ unsafe: true }` to prevent exceptions during shrinking
+#### Scenario: Reporter output
+- **WHEN** a property result has status `'invalid'`
+- **THEN** the reporter SHALL display the configuration error
+- **AND** the reporter SHALL distinguish invalid results from failures

--- a/openspec/changes/add-arbitrary-validation/tasks.md
+++ b/openspec/changes/add-arbitrary-validation/tasks.md
@@ -1,43 +1,56 @@
-# Tasks: Add Arbitrary Validation
+# Tasks: Add InvalidArbitrary
 
-## 1. Core Implementation
+## 1. Core Type Implementation
 
-- [ ] 1.1 Add `ArbitraryOptions` type with `unsafe?: boolean` to `src/arbitraries/types.ts`
-- [ ] 1.2 Update `fc.integer()` to accept options and throw on invalid range (unless unsafe)
-- [ ] 1.3 Update `fc.real()` to accept options and throw on invalid range (unless unsafe)
-- [ ] 1.4 Update `fc.nat()` to accept options and throw when `max < 0` (unless unsafe)
-- [ ] 1.5 Update `fc.array()` to accept options and throw on invalid bounds (unless unsafe)
-- [ ] 1.6 Update `fc.set()` to accept options and throw on invalid bounds (unless unsafe)
-- [ ] 1.7 Update `fc.oneof()` to accept options and throw on empty array (unless unsafe)
+- [ ] 1.1 Create `src/arbitraries/InvalidArbitrary.ts` with `InvalidArbitrary<R>` type and factory
+- [ ] 1.2 Add `isInvalidArbitrary()` type guard function
+- [ ] 1.3 Export from `src/arbitraries/index.ts`
+- [ ] 1.4 Add `_tag` discriminant to `NoArbitrary` for type narrowing (optional)
 
-## 2. Shrinking Updates
+## 2. Factory Function Updates
 
-- [ ] 2.1 Update `ArbitraryInteger.shrink()` to use `fc.integer(..., { unsafe: true })`
-- [ ] 2.2 Update `ArbitraryReal.shrink()` to use `fc.real(..., { unsafe: true })` (if applicable)
-- [ ] 2.3 Update `ArbitraryArray.shrink()` to use `fc.array(..., { unsafe: true })`
-- [ ] 2.4 Update `ArbitrarySet.shrink()` to use `fc.set(..., { unsafe: true })` (if applicable)
-- [ ] 2.5 Audit all other `shrink()` methods for unsafe factory calls
+- [ ] 2.1 Update `fc.integer()` to return `InvalidArbitrary` when `min > max`
+- [ ] 2.2 Update `fc.real()` to return `InvalidArbitrary` when `min > max`
+- [ ] 2.3 Update `fc.nat()` to return `InvalidArbitrary` when `max < 0`
+- [ ] 2.4 Update `fc.array()` to return `InvalidArbitrary` when `min > max` or `min < 0`
+- [ ] 2.5 Update `fc.set()` to return `InvalidArbitrary` when bounds invalid or `min > elements.length`
+- [ ] 2.6 Update `fc.oneof()` to return `InvalidArbitrary` when `elements` is empty
+- [ ] 2.7 Audit other factory functions for similar validation opportunities
 
-## 3. Tests
+## 3. FluentCheck Runner Updates
 
-- [ ] 3.1 Add tests for `fc.integer()` throwing on `min > max`
-- [ ] 3.2 Add tests for `fc.real()` throwing on `min > max`
-- [ ] 3.3 Add tests for `fc.nat()` throwing on `max < 0`
-- [ ] 3.4 Add tests for `fc.array()` throwing on invalid bounds
-- [ ] 3.5 Add tests for `fc.set()` throwing on invalid bounds
-- [ ] 3.6 Add tests for `fc.oneof()` throwing on empty array
-- [ ] 3.7 Add tests verifying shrinking still works with `unsafe: true`
-- [ ] 3.8 Add tests verifying existing valid code continues to work
+- [ ] 3.1 Add `'invalid'` status to `PropertyResult` type
+- [ ] 3.2 Update `FluentCheck` to detect `InvalidArbitrary` in arbitrary chain
+- [ ] 3.3 Return `invalid` result with reason when `InvalidArbitrary` detected
+- [ ] 3.4 Ensure `InvalidArbitrary` in composed arbitraries (tuple, chain, etc.) is detected
 
-## 4. Documentation
+## 4. Reporter Updates
 
-- [ ] 4.1 Update README with migration guide for breaking change
-- [ ] 4.2 Add CHANGELOG entry for breaking change
-- [ ] 4.3 Document `unsafe` option in API docs (if applicable)
+- [ ] 4.1 Add formatting for `invalid` status in `FluentReporter`
+- [ ] 4.2 Display reason and suggestion in output
+- [ ] 4.3 Ensure clear distinction from regular failures
 
-## 5. Optional: Warning Mode
+## 5. Tests
 
-- [ ] 5.1 Add `FluentCheckConfig` type with `warnOnEmpty?: boolean`
-- [ ] 5.2 Add `fc.configure()` function
-- [ ] 5.3 Emit console warning when `NoArbitrary` used in `forall`/`exists`
-- [ ] 5.4 Add tests for warning mode
+- [ ] 5.1 Add tests for `InvalidArbitrary` type and factory
+- [ ] 5.2 Add tests for `isInvalidArbitrary()` type guard
+- [ ] 5.3 Add tests for `fc.integer()` returning `InvalidArbitrary` on invalid range
+- [ ] 5.4 Add tests for `fc.real()` returning `InvalidArbitrary` on invalid range
+- [ ] 5.5 Add tests for `fc.nat()` returning `InvalidArbitrary` on negative max
+- [ ] 5.6 Add tests for `fc.array()` returning `InvalidArbitrary` on invalid bounds
+- [ ] 5.7 Add tests for `fc.set()` returning `InvalidArbitrary` on invalid bounds
+- [ ] 5.8 Add tests for `fc.oneof()` returning `InvalidArbitrary` on empty array
+- [ ] 5.9 Add tests verifying shrinking still returns `NoArbitrary` (not `InvalidArbitrary`)
+- [ ] 5.10 Add tests for FluentCheck detecting and reporting `InvalidArbitrary`
+- [ ] 5.11 Add tests for composed arbitraries containing `InvalidArbitrary`
+
+## 6. Documentation
+
+- [ ] 6.1 Update README with explanation of `InvalidArbitrary` vs `NoArbitrary`
+- [ ] 6.2 Add CHANGELOG entry for new validation behavior
+- [ ] 6.3 Document common error messages and fixes
+
+## 7. Type-Level Enhancements (Optional/Future)
+
+- [ ] 7.1 Investigate type-level guards for literal number comparisons
+- [ ] 7.2 Add branded types or conditional return types where feasible


### PR DESCRIPTION
## Summary

Adds OpenSpec change proposal for handling invalid arbitrary configurations with a new `InvalidArbitrary` type:

- **Introduce `InvalidArbitrary<Reason>`** - a new type that carries error context but behaves like an empty arbitrary
- **Preserve `NoArbitrary`** for legitimate empty sets (shrinking exhausted, filters eliminated all values)
- **FluentCheck runner detects and reports** invalid configurations with clear error messages
- **No runtime exceptions** - aligns with the framework's functional, type-safe philosophy

This approach addresses the discussion in issue #118 about `NoArbitrary` being confusing when tests pass for the "wrong" reasons (vacuous truth), while preserving the compositional nature of the API.

### Key Distinction

| Type | Meaning | Source | Test Result |
|------|---------|--------|-------------|
| `NoArbitrary` | Legitimate empty set | Internal (shrinking, filters) | Pass (vacuously true) |
| `InvalidArbitrary` | Configuration error | User API misuse | **Fail** with diagnostic |

**Proposal:** [openspec/changes/add-arbitrary-validation/proposal.md](https://github.com/fluent-check/fluent-check/blob/openspec/add-arbitrary-validation/openspec/changes/add-arbitrary-validation/proposal.md)

**Closes:** #118

## Tasks

See [openspec/changes/add-arbitrary-validation/tasks.md](https://github.com/fluent-check/fluent-check/blob/openspec/add-arbitrary-validation/openspec/changes/add-arbitrary-validation/tasks.md) for implementation checklist.

## Test Plan

- [ ] All existing tests pass
- [ ] New tests for `InvalidArbitrary` type and `isInvalidArbitrary()` guard
- [ ] Tests for factory functions returning `InvalidArbitrary` on invalid inputs
- [ ] Tests verifying shrinking still returns `NoArbitrary`
- [ ] Tests for FluentCheck detecting and reporting invalid configurations
- [ ] `openspec validate add-arbitrary-validation --strict` passes