### PR TITLE
refactor: enables full strict mode

### DIFF
--- a/openspec/changes/ts-modernise-reduce-type-assertions/tasks.md
+++ b/openspec/changes/ts-modernise-reduce-type-assertions/tasks.md
@@ -2,70 +2,88 @@
 
 ## 1. Investigation & Baseline
 
-- [ ] 1.1 Run `tsc --noEmit` to capture current state (should pass)
-- [ ] 1.2 Document all 14 `as unknown as` assertion locations:
+- [x] 1.1 Run `tsc --noEmit` to capture current state (should pass)
+- [x] 1.2 Document all 14 `as unknown as` assertion locations:
   - `src/arbitraries/index.ts`: lines 21, 24, 30, 33, 41, 44, 48, 53
   - `src/arbitraries/regex.ts`: lines 11, 13, 16, 19, 24
   - `src/arbitraries/ArbitraryTuple.ts`: line 57
-- [ ] 1.3 Test if simply removing assertions causes compile errors (document which ones)
-- [ ] 1.4 Analyze why `Arbitrary<never>` (NoArbitrary) doesn't unify with `Arbitrary<T>`
+- [x] 1.3 Test if simply removing assertions causes compile errors (document which ones)
+- [x] 1.4 Analyze why `Arbitrary<never>` (NoArbitrary) doesn't unify with `Arbitrary<T>`
 
 ## 2. Enable Full Strict Mode
 
-- [ ] 2.1 Enable `strict: true` in `tsconfig.json`
-- [ ] 2.2 Remove redundant individual strict flags (now implied by `strict: true`)
-- [ ] 2.3 Fix any new errors that surface from strict mode
-- [ ] 2.4 Run tests to ensure no regressions
+- [x] 2.1 Enable `strict: true` in `tsconfig.json`
+- [x] 2.2 Remove redundant individual strict flags (now implied by `strict: true`)
+- [x] 2.3 Fix any new errors that surface from strict mode
+- [x] 2.4 Run tests to ensure no regressions
 
 ## 3. Fix NoArbitrary Pattern
 
-- [ ] 3.1 Evaluate options:
+- [x] 3.1 Evaluate options:
   - Option A: Generic `noArbitrary<T>()` factory function
-  - Option B: Explicit if-statement bodies (avoids ternary inference issues)
+  - Option B: Explicit if-statement bodies (avoids ternary inference issues) ✅ **Chosen**
   - Option C: Explicit return type annotations on factory functions
-- [ ] 3.2 Implement chosen solution in `src/arbitraries/NoArbitrary.ts` (if needed)
-- [ ] 3.3 Update `src/arbitraries/internal.ts` exports (if needed)
+- [x] 3.2 Implement chosen solution in `src/arbitraries/NoArbitrary.ts` (if needed)
+  - No changes needed - Option B works with existing NoArbitrary
+- [x] 3.3 Update `src/arbitraries/internal.ts` exports (if needed)
+  - No changes needed
 
 ## 4. Remove Assertions - index.ts (9 instances)
 
-- [ ] 4.1 Fix `integer()` function (line 21) - 2 assertions
-- [ ] 4.2 Fix `real()` function (line 24) - 2 assertions
-- [ ] 4.3 Fix `array()` function (line 30) - 1 assertion
-- [ ] 4.4 Fix `set()` function (line 33) - 1 assertion
-- [ ] 4.5 Fix `union()` function (line 41) - 1 assertion
-- [ ] 4.6 Fix `boolean()` function (line 44) - 1 assertion
-- [ ] 4.7 Fix `constant()` function (line 48) - 1 assertion
-- [ ] 4.8 Fix `tuple()` function (line 53) - 1 assertion
+- [x] 4.1 Fix `integer()` function (line 21) - 2 assertions → refactored to if-statements
+- [x] 4.2 Fix `real()` function (line 24) - 2 assertions → refactored to if-statements
+- [x] 4.3 Fix `array()` function (line 30) - 1 assertion → refactored to if-statements
+- [x] 4.4 Fix `set()` function (line 33) - 1 assertion → refactored to if-statements
+- [x] 4.5 Fix `union()` function (line 41) - 1 assertion → refactored with filtered variable
+- [x] 4.6 Fix `boolean()` function (line 44) - 1 assertion → removed, direct return
+- [x] 4.7 Fix `constant()` function (line 48) - 1 assertion → removed, direct return
+- [x] 4.8 Fix `tuple()` function (line 53) - 1 assertion → reduced to simple `as Arbitrary<>` cast
 
 ## 5. Remove Assertions - regex.ts (5 instances)
 
-- [ ] 5.1 Fix local `integer()` function (line 11) - 2 assertions
-- [ ] 5.2 Fix local `constant()` function (line 13) - 1 assertion
-- [ ] 5.3 Fix local `array()` function (line 16) - 1 assertion
-- [ ] 5.4 Fix local `tuple()` function (line 19) - 1 assertion
-- [ ] 5.5 Fix local `union()` function (line 24) - 1 assertion
-- [ ] 5.6 Consider: refactor to use exported functions from `index.ts` instead of duplicating
+- [x] 5.1 Fix local `integer()` function (line 11) - 2 assertions → refactored to if-statements
+- [x] 5.2 Fix local `constant()` function (line 13) - 1 assertion → removed, direct return
+- [x] 5.3 Fix local `array()` function (line 16) - 1 assertion → refactored to if-statements
+- [x] 5.4 Fix local `tuple()` function (line 19) - 1 assertion → removed, direct return
+- [x] 5.5 Fix local `union()` function (line 24) - 1 assertion → refactored with filtered variable
+- [x] 5.6 Consider: refactor to use exported functions from `index.ts` instead of duplicating
+  - Kept local implementations to avoid circular dependencies (documented in comments)
 
 ## 6. Remove Assertions - ArbitraryTuple.ts (1 instance)
 
-- [ ] 6.1 Fix `shrink()` method (line 57) - analyze recursive type inference issue
-- [ ] 6.2 May require explicit type annotation on the fc.union/fc.tuple chain
+- [x] 6.1 Fix `shrink()` method (line 57) - analyze recursive type inference issue
+  - Reduced to simple `as Arbitrary<A>` cast (not `as unknown as`)
+- [x] 6.2 May require explicit type annotation on the fc.union/fc.tuple chain
+  - Used `as unknown[]` for value/original arrays to enable indexing
 
 ## 7. Verification & Cleanup
 
-- [ ] 7.1 Run `tsc --noEmit` - must pass with zero errors
-- [ ] 7.2 Run full test suite (`npm test`) - must pass
-- [ ] 7.3 Grep for remaining `as unknown as` - should be zero
-- [ ] 7.4 Grep for `as any` - document if any exist (future cleanup candidate)
+- [x] 7.1 Run `tsc --noEmit` - must pass with zero errors
+- [x] 7.2 Run full test suite (`npm test`) - must pass (125 tests passing)
+- [x] 7.3 Grep for remaining `as unknown as` - **zero found** ✅
+- [x] 7.4 Grep for `as any` - **zero found** ✅
 - [ ] 7.5 Consider adding ESLint rule: `@typescript-eslint/no-unnecessary-type-assertion`
+  - Deferred to future enhancement
 
 ## 8. Documentation
 
-- [ ] 8.1 Update any inline comments explaining type patterns
-- [ ] 8.2 Document the NoArbitrary pattern in code if non-obvious
+- [x] 8.1 Update any inline comments explaining type patterns
+  - Kept existing comment about circular dependencies in regex.ts
+- [x] 8.2 Document the NoArbitrary pattern in code if non-obvious
+  - Pattern is now self-explanatory with explicit if-statements
+
+## Additional Changes
+
+- [x] Added `jstat.d.ts` type declarations for the jstat module (required for strict mode)
+- [x] Fixed strict mode errors in FluentCheck.ts (indexing issues)
+- [x] Fixed strict mode errors in ArbitraryTuple.ts (unknown[] indexing)
+- [x] Updated charClassMap type in regex.ts from `Record<CharClassKey, ...>` to `Record<string, ...>` for string indexing
 
 ## Notes
 
-- Tasks in sections 4-6 can be done incrementally; each fix should be verified independently
-- If a specific assertion cannot be removed without architectural changes, document why and consider if the architectural change is worth it
-- The `regex.ts` local functions (section 5) may be candidates for refactoring to reuse `index.ts` exports
+- All 14 `as unknown as` assertions have been eliminated
+- 2 simple `as Arbitrary<T>` casts remain (type-safe, not bypassing type checking):
+  - `index.ts:65` - ArbitraryTuple cast for UnwrapFluentPick
+  - `ArbitraryTuple.ts:59` - shrink method return type
+- Full strict mode (`strict: true`) is now enabled
+- All 125 tests pass

--- a/src/FluentCheck.ts
+++ b/src/FluentCheck.ts
@@ -97,7 +97,7 @@ export class FluentCheck<Rec extends ParentRec, ParentRec extends {}> {
   }
 
   static unwrapFluentPick<T>(testCase: PickResult<T>): ValueResult<T> {
-    const result = {}
+    const result: Record<string, T> = {}
     for (const k in testCase) result[k] = testCase[k].value
     return result
   }
@@ -170,7 +170,7 @@ class FluentCheckGivenConstant<K extends string, V, Rec extends ParentRec & Reco
   }
 
   protected run(testCase: Rec, callback: (arg: Rec) => FluentResult) {
-    testCase[this.name as string] = this.value
+    (testCase as Record<string, V>)[this.name] = this.value
     return callback(testCase)
   }
 }
@@ -240,14 +240,14 @@ class FluentCheckAssert<Rec extends ParentRec, ParentRec extends {}> extends Flu
   }
 
   private runPreliminaries<T>(testCase: ValueResult<T>): Rec {
-    const data = { } as Rec
+    const data: Record<string, unknown> = {}
 
     this.preliminaries.forEach(node => {
       if (node instanceof FluentCheckGivenMutable) data[node.name] = node.factory({...testCase, ...data})
       else if (node instanceof FluentCheckWhen) node.f({...testCase, ...data})
     })
 
-    return data
+    return data as Rec
   }
 
   protected run(testCase: WrapFluentPick<Rec>,

--- a/src/arbitraries/ArbitraryTuple.ts
+++ b/src/arbitraries/ArbitraryTuple.ts
@@ -49,18 +49,22 @@ export class ArbitraryTuple<U extends Arbitrary<any>[], A = UnwrapArbitrary<U>> 
   }
 
   shrink(initial: FluentPick<A>): Arbitrary<A> {
+    const value = initial.value as unknown[]
+    const original = initial.original as unknown[]
     return fc.union(...this.arbitraries.map((_, selected) =>
       fc.tuple(...this.arbitraries.map((arbitrary, i) =>
         selected === i ?
-          arbitrary.shrink({value: initial.value[i], original: initial.original[i]}) :
-          fc.constant(initial.value[i])
-      )))) as unknown as Arbitrary<A>
+          arbitrary.shrink({value: value[i], original: original[i]}) :
+          fc.constant(value[i])
+      )))) as Arbitrary<A>
   }
 
   canGenerate(pick: FluentPick<A>): boolean {
-    for (const i in pick.value) {
+    const value = pick.value as unknown[]
+    const original = pick.original as unknown[]
+    for (const i in value) {
       const index = Number(i)
-      if (!this.arbitraries[index].canGenerate({value: pick.value[index], original: pick.original[index]}))
+      if (!this.arbitraries[index].canGenerate({value: value[index], original: original[index]}))
         return false
     }
 

--- a/src/arbitraries/index.ts
+++ b/src/arbitraries/index.ts
@@ -17,37 +17,50 @@ export {char, hex, base64, ascii, unicode, string} from './string.js'
 export {date, time, datetime, duration, timeToMilliseconds} from './datetime.js'
 export {regex, patterns, shrinkRegexString} from './regex.js'
 
-export const integer = (min = Number.MIN_SAFE_INTEGER, max = Number.MAX_SAFE_INTEGER): Arbitrary<number> =>
-  min > max ? NoArbitrary : min === max ? new ArbitraryConstant(min) as unknown as Arbitrary<number> : new ArbitraryInteger(min, max) as unknown as Arbitrary<number>
+export const integer = (min = Number.MIN_SAFE_INTEGER, max = Number.MAX_SAFE_INTEGER): Arbitrary<number> => {
+  if (min > max) return NoArbitrary
+  if (min === max) return new ArbitraryConstant(min)
+  return new ArbitraryInteger(min, max)
+}
 
-export const real = (min = Number.MIN_SAFE_INTEGER, max = Number.MAX_SAFE_INTEGER): Arbitrary<number> =>
-  min > max ? NoArbitrary : min === max ? new ArbitraryConstant(min) as unknown as Arbitrary<number> : new ArbitraryReal(min, max) as unknown as Arbitrary<number>
+export const real = (min = Number.MIN_SAFE_INTEGER, max = Number.MAX_SAFE_INTEGER): Arbitrary<number> => {
+  if (min > max) return NoArbitrary
+  if (min === max) return new ArbitraryConstant(min)
+  return new ArbitraryReal(min, max)
+}
 
 export const nat = (min = 0, max = Number.MAX_SAFE_INTEGER): Arbitrary<number> =>
   max < 0 ? NoArbitrary : integer(Math.max(0, min), max)
 
-export const array = <A>(arbitrary: Arbitrary<A>, min = 0, max = 10): Arbitrary<A[]> =>
-  min > max ? NoArbitrary : new ArbitraryArray(arbitrary, min, max) as unknown as Arbitrary<A[]>
+export const array = <A>(arbitrary: Arbitrary<A>, min = 0, max = 10): Arbitrary<A[]> => {
+  if (min > max) return NoArbitrary
+  return new ArbitraryArray(arbitrary, min, max)
+}
 
-export const set = <A>(elements: A[], min = 0, max = 10): Arbitrary<A[]> =>
-  min > max || min > elements.length ? NoArbitrary : new ArbitrarySet(Array.from(new Set(elements)), min, max) as unknown as Arbitrary<A[]>
+export const set = <A>(elements: A[], min = 0, max = 10): Arbitrary<A[]> => {
+  if (min > max || min > elements.length) return NoArbitrary
+  return new ArbitrarySet(Array.from(new Set(elements)), min, max)
+}
 
 export const oneof = <A>(elements: A[]): Arbitrary<A> =>
   elements.length === 0 ? NoArbitrary : integer(0, elements.length - 1).map(i => elements[i])
 
 export const union = <A>(...arbitraries: Arbitrary<A>[]): Arbitrary<A> => {
-  arbitraries = arbitraries.filter(a => a !== NoArbitrary)
-  return arbitraries.length === 0 ? NoArbitrary :
-    arbitraries.length === 1 ? arbitraries[0] : new ArbitraryComposite(arbitraries) as unknown as Arbitrary<A>
+  const filtered = arbitraries.filter(a => a !== NoArbitrary)
+  if (filtered.length === 0) return NoArbitrary
+  if (filtered.length === 1) return filtered[0]
+  return new ArbitraryComposite(filtered)
 }
 
-export const boolean = (): Arbitrary<boolean> => new ArbitraryBoolean() as unknown as Arbitrary<boolean>
+export const boolean = (): Arbitrary<boolean> => new ArbitraryBoolean()
 
 export const empty = () => NoArbitrary
 
-export const constant = <A>(constant: A): Arbitrary<A> => new ArbitraryConstant(constant) as unknown as Arbitrary<A>
+export const constant = <A>(constant: A): Arbitrary<A> => new ArbitraryConstant(constant)
 
 type UnwrapFluentPick<T> = { [P in keyof T]: T[P] extends Arbitrary<infer E> ? E : T[P] }
 
-export const tuple = <U extends Arbitrary<any>[]>(...arbitraries: U): Arbitrary<UnwrapFluentPick<U>> =>
-  arbitraries.some(a => a === NoArbitrary) ? NoArbitrary : new ArbitraryTuple(arbitraries) as unknown as Arbitrary<UnwrapFluentPick<U>>
+export const tuple = <U extends Arbitrary<any>[]>(...arbitraries: U): Arbitrary<UnwrapFluentPick<U>> => {
+  if (arbitraries.some(a => a === NoArbitrary)) return NoArbitrary
+  return new ArbitraryTuple(arbitraries) as Arbitrary<UnwrapFluentPick<U>>
+}

--- a/src/jstat.d.ts
+++ b/src/jstat.d.ts
@@ -1,0 +1,24 @@
+declare module 'jstat' {
+  export const beta: {
+    mean(alpha: number, beta: number): number
+    mode(alpha: number, beta: number): number
+    pdf(x: number, alpha: number, beta: number): number
+    cdf(x: number, alpha: number, beta: number): number
+    inv(p: number, alpha: number, beta: number): number
+  }
+
+  export const binomial: {
+    pdf(k: number, n: number, p: number): number
+    cdf(k: number, n: number, p: number): number
+  }
+
+  export function gammaln(x: number): number
+
+  const jstat: {
+    beta: typeof beta
+    binomial: typeof binomial
+    gammaln: typeof gammaln
+  }
+
+  export default jstat
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,11 +8,11 @@
     "outDir": "dist",
     "sourceMap": true,
     
-    "strictNullChecks": true,
-    "strictFunctionTypes": true,
-    "strictPropertyInitialization": true,
-    "noImplicitThis": true
+    "strict": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist"],
+  "ts-node": {
+    "files": true
+  }
 }


### PR DESCRIPTION
## Summary

Implements openspec change proposal to reduce type assertions.

- Eliminates all 14 `as unknown as` type assertions from factory functions
- Enables full strict mode (`strict: true`) in tsconfig.json
- Refactors ternary expressions to if-statements for better type inference
- Adds jstat.d.ts type declarations for strict mode compatibility

**Proposal:** openspec/changes/ts-modernise-reduce-type-assertions/proposal.md
**Closes:** #383

## Tasks

See `openspec/changes/ts-modernise-reduce-type-assertions/tasks.md` for implementation checklist.

## Test Plan

- [x] All existing tests pass (125 tests)
- [x] `tsc --noEmit` passes with zero errors
- [x] No `as unknown as` assertions remain
- [x] No `as any` assertions exist