### PR TITLE
feat: add fc.pre() precondition assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,42 @@ fc.scenario()
   .check()
 ```
 
+### Preconditions
+
+Use `fc.pre()` to skip test cases that don't meet certain preconditions. This is clearer than using `filter()` when the constraint applies to the test logic rather than the data generation:
+
+```typescript
+// Skip division by zero cases
+fc.scenario()
+  .forall('a', fc.integer(-100, 100))
+  .forall('b', fc.integer(-10, 10))
+  .then(({a, b}) => {
+    fc.pre(b !== 0);  // Skip if b is zero
+    return Math.trunc(a / b) * b + (a % b) === a;
+  })
+  .check();
+
+// With a descriptive message for debugging
+fc.scenario()
+  .forall('arr', fc.array(fc.integer()))
+  .then(({arr}) => {
+    fc.pre(arr.length > 0, 'array must be non-empty');
+    return arr[0] !== undefined;
+  })
+  .check();
+```
+
+**When to use `pre()` vs `filter()`:**
+
+| Use Case | Approach |
+|----------|----------|
+| Constraint on data generation | `filter()` on arbitrary |
+| Constraint discovered during test | `fc.pre()` in test body |
+| Multiple values must relate | `fc.pre()` in test body |
+| Improves readability of intent | `fc.pre()` in test body |
+
+The result includes a `skipped` count showing how many test cases were skipped due to failed preconditions. Skipped cases count as neither passes nor failures.
+
 ## Detailed Documentation
 
 For more details on each feature, check out our detailed documentation:

--- a/openspec/changes/add-preconditions/tasks.md
+++ b/openspec/changes/add-preconditions/tasks.md
@@ -1,29 +1,29 @@
 # Implementation Tasks
 
 ## 1. Core Implementation
-- [ ] 1.1 Create `PreconditionFailure` error class
-- [ ] 1.2 Implement `pre()` function with type assertion
-- [ ] 1.3 Add optional message parameter support
-- [ ] 1.4 Modify `FluentCheckAssert.run()` to catch `PreconditionFailure`
-- [ ] 1.5 Handle skipped cases appropriately (neither pass nor fail)
+- [x] 1.1 Create `PreconditionFailure` error class
+- [x] 1.2 Implement `pre()` function with type assertion
+- [x] 1.3 Add optional message parameter support
+- [x] 1.4 Modify `FluentCheckAssert.run()` to catch `PreconditionFailure`
+- [x] 1.5 Handle skipped cases appropriately (neither pass nor fail)
 
 ## 2. Statistics (Optional Enhancement)
-- [ ] 2.1 Add skip count to `FluentResult`
+- [x] 2.1 Add skip count to `FluentResult`
 - [ ] 2.2 Track precondition failure reasons if messages provided
 - [ ] 2.3 Add warning if skip rate exceeds threshold (e.g., 50%)
 
 ## 3. Export & Integration
-- [ ] 3.1 Export `pre` from `src/index.ts`
-- [ ] 3.2 Export `PreconditionFailure` for advanced users
+- [x] 3.1 Export `pre` from `src/index.ts`
+- [x] 3.2 Export `PreconditionFailure` for advanced users
 
 ## 4. Testing
-- [ ] 4.1 Add unit tests for basic precondition usage
-- [ ] 4.2 Add tests for precondition with message
-- [ ] 4.3 Add tests verifying skipped cases don't count as failures
-- [ ] 4.4 Add tests for multiple preconditions in same test
-- [ ] 4.5 Add integration tests with division by zero scenario
+- [x] 4.1 Add unit tests for basic precondition usage
+- [x] 4.2 Add tests for precondition with message
+- [x] 4.3 Add tests verifying skipped cases don't count as failures
+- [x] 4.4 Add tests for multiple preconditions in same test
+- [x] 4.5 Add integration tests with division by zero scenario
 
 ## 5. Documentation
-- [ ] 5.1 Add JSDoc comments explaining precondition semantics
-- [ ] 5.2 Update README with precondition examples
-- [ ] 5.3 Document difference between `filter()` and `pre()`
+- [x] 5.1 Add JSDoc comments explaining precondition semantics
+- [x] 5.2 Update README with precondition examples
+- [x] 5.3 Document difference between `filter()` and `pre()`

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
-import {FluentCheck} from './FluentCheck.js'
+import {FluentCheck, pre, PreconditionFailure} from './FluentCheck.js'
 import {FluentStrategyFactory} from './strategies/FluentStrategyFactory.js'
 export {expect} from './FluentReporter.js'
+export {pre, PreconditionFailure}
 export const scenario = () => new FluentCheck()
 export const strategy = () => new FluentStrategyFactory()
 export {

--- a/test/preconditions.test.ts
+++ b/test/preconditions.test.ts
@@ -1,0 +1,143 @@
+import * as fc from '../src/index'
+import {it} from 'mocha'
+import {expect} from 'chai'
+
+describe('Precondition tests', () => {
+  it('Basic precondition - test passes when precondition is true', () => {
+    const result = fc.scenario()
+      .forall('n', fc.integer(1, 100))
+      .then(({n}) => {
+        fc.pre(n > 0)
+        return n > 0
+      })
+      .check()
+
+    expect(result.satisfiable).to.equal(true)
+  })
+
+  it('Basic precondition - test skips when precondition is false', () => {
+    const result = fc.scenario()
+      .forall('n', fc.integer(-10, 10))
+      .then(({n}) => {
+        fc.pre(n > 100) // Always false in range -10 to 10
+        return true
+      })
+      .check()
+
+    // All test cases should be skipped
+    expect(result.skipped).to.be.greaterThan(0)
+  })
+
+  it('Precondition with message - message is available in PreconditionFailure', () => {
+    const message = 'value must be positive'
+    let caughtMessage: string | undefined
+
+    try {
+      fc.pre(false, message)
+    } catch (e) {
+      if (e instanceof fc.PreconditionFailure) {
+        caughtMessage = e.message
+      }
+    }
+
+    expect(caughtMessage).to.equal(message)
+  })
+
+  it('Precondition passes - execution continues normally', () => {
+    let afterPreExecuted = false
+
+    const result = fc.scenario()
+      .forall('n', fc.integer(1, 10))
+      .then(({n}) => {
+        fc.pre(n >= 1)
+        afterPreExecuted = true
+        return n >= 1
+      })
+      .check()
+
+    expect(result.satisfiable).to.equal(true)
+    expect(afterPreExecuted).to.equal(true)
+  })
+
+  it('Multiple preconditions - all must pass', () => {
+    const result = fc.scenario()
+      .forall('a', fc.integer(1, 100))
+      .forall('b', fc.integer(1, 100))
+      .then(({a, b}) => {
+        fc.pre(a > 0)
+        fc.pre(b > 0)
+        fc.pre(a + b > 0)
+        return a + b > 0
+      })
+      .check()
+
+    expect(result.satisfiable).to.equal(true)
+  })
+
+  it('Multiple preconditions - first failing skips the test', () => {
+    const result = fc.scenario()
+      .forall('n', fc.integer(-100, 100))
+      .then(({n}) => {
+        fc.pre(n > 1000) // Always false
+        fc.pre(n > 2000) // Never reached
+        return true
+      })
+      .check()
+
+    expect(result.skipped).to.be.greaterThan(0)
+  })
+
+  it('Division by zero scenario - skip when divisor is zero', () => {
+    const result = fc.scenario()
+      .forall('a', fc.integer(0, 100))
+      .forall('b', fc.integer(-10, 10))
+      .then(({a, b}) => {
+        fc.pre(b !== 0) // Skip division by zero cases
+        // For non-negative a and non-zero b, this property holds
+        const quotient = Math.trunc(a / b)
+        const remainder = a % b
+        return quotient * b + remainder === a
+      })
+      .check()
+
+    expect(result.satisfiable).to.equal(true)
+    // Some cases with b=0 should have been skipped
+    expect(result.skipped).to.be.greaterThan(0)
+  })
+
+  it('Skipped cases do not count as failures', () => {
+    // This test would fail without preconditions because some cases
+    // would violate the assertion. With preconditions, those cases
+    // are skipped instead.
+    const result = fc.scenario()
+      .forall('n', fc.integer(-10, 10))
+      .then(({n}) => {
+        fc.pre(n > 0) // Only test positive numbers
+        return n > 0
+      })
+      .check()
+
+    expect(result.satisfiable).to.equal(true)
+    expect(result.skipped).to.be.greaterThan(0)
+  })
+
+  it('PreconditionFailure can be caught and inspected', () => {
+    expect(() => fc.pre(false)).to.throw(fc.PreconditionFailure)
+  })
+
+  it('Type narrowing works with preconditions', () => {
+    // This is a compile-time check - if fc.pre has correct type assertion,
+    // the type of value after fc.pre should be narrowed
+    const result = fc.scenario()
+      .forall('value', fc.union(fc.integer(1, 10), fc.constant(null as null)))
+      .then(({value}) => {
+        fc.pre(value !== null)
+        // After fc.pre, TypeScript should know value is not null
+        // This is primarily a compile-time check
+        return typeof value === 'number'
+      })
+      .check()
+
+    expect(result.satisfiable).to.equal(true)
+  })
+})


### PR DESCRIPTION
## Summary

Implements openspec change proposal for adding precondition assertions.

- Add `fc.pre()` function for asserting preconditions within property test bodies
- When precondition fails, test case is skipped (neither pass nor fail)
- Track skip statistics in `FluentResult.skipped`
- Support optional message parameter for debugging

**Proposal:** openspec/changes/add-preconditions/proposal.md
**Closes:** #407

## Tasks

See `openspec/changes/add-preconditions/tasks.md` for implementation checklist.

## Test Plan

- [x] All existing tests pass (151 tests)
- [x] New tests added for precondition scenarios
- [x] `openspec validate add-preconditions --strict` passes