### PR TITLE
feat: add fc.prop() shorthand for simple property tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,44 @@ fc.scenario()
   .assertSatisfiable();
 ```
 
+### Property Shorthand (`fc.prop()`)
+
+For simple properties that don't need the full BDD structure, use the `prop()` shorthand for minimal boilerplate:
+
+```typescript
+import * as fc from 'fluent-check';
+
+// Single arbitrary - 80% less verbose than scenario()
+fc.prop(fc.integer(), x => x + 0 === x).assert();
+
+// Multiple arbitraries (up to 5)
+fc.prop(fc.integer(), fc.integer(), (a, b) => a + b === b + a).assert();
+
+// With custom strategy configuration
+fc.prop(fc.integer(), x => x > 0)
+  .config(fc.strategy().defaultStrategy())
+  .assert();
+
+// Check without throwing (returns FluentResult)
+const result = fc.prop(fc.integer(), x => x >= 0).check();
+if (!result.satisfiable) {
+  console.log('Counterexample:', result.example);
+}
+```
+
+**Comparison:**
+```typescript
+// Before (verbose BDD-style)
+fc.scenario()
+  .forall('x', fc.integer())
+  .then(({x}) => x + 0 === x)
+  .check()
+  .assertSatisfiable();
+
+// After (shorthand) - 80% reduction
+fc.prop(fc.integer(), x => x + 0 === x).assert();
+```
+
 ### Fluent Assertions
 
 FluentCheck provides built-in assertion methods that integrate seamlessly with the fluent API:

--- a/openspec/changes/add-prop-shorthand/tasks.md
+++ b/openspec/changes/add-prop-shorthand/tasks.md
@@ -1,30 +1,30 @@
 # Implementation Tasks
 
 ## 1. Core Implementation
-- [ ] 1.1 Create `FluentProperty` interface in `src/FluentProperty.ts`
-- [ ] 1.2 Implement `prop()` function with single arbitrary overload
-- [ ] 1.3 Add overloads for 2-5 arbitraries
-- [ ] 1.4 Implement `check()` method delegating to `scenario().forall().then().check()`
-- [ ] 1.5 Implement `assert()` method with descriptive error messages
-- [ ] 1.6 Implement `config()` method for strategy configuration
+- [x] 1.1 Create `FluentProperty` interface in `src/FluentProperty.ts`
+- [x] 1.2 Implement `prop()` function with single arbitrary overload
+- [x] 1.3 Add overloads for 2-5 arbitraries
+- [x] 1.4 Implement `check()` method delegating to `scenario().forall().then().check()`
+- [x] 1.5 Implement `assert()` method with descriptive error messages
+- [x] 1.6 Implement `config()` method for strategy configuration
 
 ## 2. Type Safety
-- [ ] 2.1 Ensure full type inference for property function parameters
-- [ ] 2.2 Add type tests for all overloads
-- [ ] 2.3 Verify IDE autocomplete works correctly
+- [x] 2.1 Ensure full type inference for property function parameters
+- [x] 2.2 Add type tests for all overloads
+- [x] 2.3 Verify IDE autocomplete works correctly
 
 ## 3. Export & Integration
-- [ ] 3.1 Export `prop` from `src/index.ts`
-- [ ] 3.2 Export `FluentProperty` type for advanced users
+- [x] 3.1 Export `prop` from `src/index.ts`
+- [x] 3.2 Export `FluentProperty` type for advanced users
 
 ## 4. Testing
-- [ ] 4.1 Add unit tests for single arbitrary case
-- [ ] 4.2 Add unit tests for multiple arbitraries (2-5)
-- [ ] 4.3 Add tests for `assert()` throwing behavior
-- [ ] 4.4 Add tests for `config()` with strategies
-- [ ] 4.5 Add integration tests with real property scenarios
+- [x] 4.1 Add unit tests for single arbitrary case
+- [x] 4.2 Add unit tests for multiple arbitraries (2-5)
+- [x] 4.3 Add tests for `assert()` throwing behavior
+- [x] 4.4 Add tests for `config()` with strategies
+- [x] 4.5 Add integration tests with real property scenarios
 
 ## 5. Documentation
-- [ ] 5.1 Add JSDoc comments to all public APIs
-- [ ] 5.2 Update README with shorthand examples
-- [ ] 5.3 Add migration guide showing before/after
+- [x] 5.1 Add JSDoc comments to all public APIs
+- [x] 5.2 Update README with shorthand examples
+- [x] 5.3 Add migration guide showing before/after

--- a/src/FluentProperty.ts
+++ b/src/FluentProperty.ts
@@ -1,0 +1,229 @@
+import {Arbitrary} from './arbitraries/index.js'
+import {FluentCheck, FluentResult} from './FluentCheck.js'
+import {FluentStrategyFactory} from './strategies/FluentStrategyFactory.js'
+
+/**
+ * A fluent property test builder that provides a simplified API for property-based testing.
+ * 
+ * @typeParam Args - Tuple type of the generated values from arbitraries
+ * 
+ * @example
+ * ```typescript
+ * // Single arbitrary
+ * fc.prop(fc.integer(), x => x + 0 === x).assert();
+ * 
+ * // Multiple arbitraries
+ * fc.prop(fc.integer(), fc.integer(), (a, b) => a + b === b + a).assert();
+ * 
+ * // With configuration
+ * fc.prop(fc.integer(), x => x > 0)
+ *   .config(fc.strategy().withShrinking())
+ *   .assert();
+ * ```
+ */
+export interface FluentProperty<Args extends unknown[]> {
+  /**
+   * Check the property and return a result without throwing.
+   * 
+   * @returns A `FluentResult` containing the test outcome and any counterexample found
+   * 
+   * @example
+   * ```typescript
+   * const result = fc.prop(fc.integer(), x => x >= 0).check();
+   * if (!result.satisfiable) {
+   *   console.log('Counterexample:', result.example);
+   * }
+   * ```
+   */
+  check(): FluentResult<Record<string, unknown>>
+
+  /**
+   * Check the property and throw an error if it fails.
+   * 
+   * @param message - Optional custom message prefix for the error
+   * @throws Error if the property is not satisfiable, with a descriptive message including the counterexample
+   * 
+   * @example
+   * ```typescript
+   * // Basic assertion
+   * fc.prop(fc.integer(), x => x + 0 === x).assert();
+   * 
+   * // With custom message
+   * fc.prop(fc.integer(), x => x > 0).assert('Integer should be positive');
+   * ```
+   */
+  assert(message?: string): void
+
+  /**
+   * Configure the property with a custom strategy.
+   * 
+   * @param strategyFactory - A strategy factory to configure test execution
+   * @returns A new `FluentProperty` with the configured strategy
+   * 
+   * @example
+   * ```typescript
+   * fc.prop(fc.integer(), x => x > 0)
+   *   .config(fc.strategy().withShrinking())
+   *   .assert();
+   * ```
+   */
+  config(strategyFactory: FluentStrategyFactory): FluentProperty<Args>
+}
+
+/**
+ * Internal implementation of FluentProperty.
+ */
+class FluentPropertyImpl<Args extends unknown[]> implements FluentProperty<Args> {
+  constructor(
+    private readonly arbitraries: Arbitrary<unknown>[],
+    private readonly predicate: (...args: Args) => boolean,
+    private readonly strategyFactory?: FluentStrategyFactory
+  ) {}
+
+  check(): FluentResult<Record<string, unknown>> {
+    let checker = new FluentCheck()
+    
+    if (this.strategyFactory) {
+      checker = checker.config(this.strategyFactory)
+    }
+
+    // Build the chain with positional argument names
+    let chain: FluentCheck<Record<string, unknown>, Record<string, unknown>> = checker as FluentCheck<Record<string, unknown>, Record<string, unknown>>
+    
+    for (let i = 0; i < this.arbitraries.length; i++) {
+      chain = chain.forall(`arg${i}`, this.arbitraries[i])
+    }
+
+    // Create the predicate wrapper that extracts positional arguments
+    const wrappedPredicate = (args: Record<string, unknown>): boolean => {
+      const positionalArgs = this.arbitraries.map((_, i) => args[`arg${i}`]) as Args
+      return this.predicate(...positionalArgs)
+    }
+
+    return chain.then(wrappedPredicate).check()
+  }
+
+  assert(message?: string): void {
+    const result = this.check()
+    if (!result.satisfiable) {
+      const prefix = message ? `${message}: ` : ''
+      // Extract positional arguments for cleaner error message
+      const args = this.arbitraries.map((_, i) => result.example[`arg${i}`])
+      const argsStr = args.length === 1 
+        ? JSON.stringify(args[0]) 
+        : `(${args.map(a => JSON.stringify(a)).join(', ')})`
+      const seedStr = result.seed !== undefined ? ` (seed: ${result.seed})` : ''
+      throw new Error(`${prefix}Property failed with counterexample: ${argsStr}${seedStr}`)
+    }
+  }
+
+  config(strategyFactory: FluentStrategyFactory): FluentProperty<Args> {
+    return new FluentPropertyImpl(this.arbitraries, this.predicate, strategyFactory)
+  }
+}
+
+// Overloads for 1-5 arbitraries
+
+/**
+ * Create a property test with a single arbitrary.
+ * 
+ * @param arb - The arbitrary to generate test values
+ * @param predicate - A function that returns true if the property holds
+ * @returns A `FluentProperty` that can be checked or asserted
+ * 
+ * @example
+ * ```typescript
+ * fc.prop(fc.integer(), x => x + 0 === x).assert();
+ * ```
+ */
+export function prop<A>(
+  arb: Arbitrary<A>,
+  predicate: (a: A) => boolean
+): FluentProperty<[A]>
+
+/**
+ * Create a property test with two arbitraries.
+ * 
+ * @param arb1 - First arbitrary
+ * @param arb2 - Second arbitrary
+ * @param predicate - A function that returns true if the property holds
+ * @returns A `FluentProperty` that can be checked or asserted
+ * 
+ * @example
+ * ```typescript
+ * fc.prop(fc.integer(), fc.integer(), (a, b) => a + b === b + a).assert();
+ * ```
+ */
+export function prop<A, B>(
+  arb1: Arbitrary<A>,
+  arb2: Arbitrary<B>,
+  predicate: (a: A, b: B) => boolean
+): FluentProperty<[A, B]>
+
+/**
+ * Create a property test with three arbitraries.
+ * 
+ * @param arb1 - First arbitrary
+ * @param arb2 - Second arbitrary
+ * @param arb3 - Third arbitrary
+ * @param predicate - A function that returns true if the property holds
+ * @returns A `FluentProperty` that can be checked or asserted
+ * 
+ * @example
+ * ```typescript
+ * fc.prop(fc.integer(), fc.integer(), fc.integer(), 
+ *   (a, b, c) => (a + b) + c === a + (b + c)
+ * ).assert();
+ * ```
+ */
+export function prop<A, B, C>(
+  arb1: Arbitrary<A>,
+  arb2: Arbitrary<B>,
+  arb3: Arbitrary<C>,
+  predicate: (a: A, b: B, c: C) => boolean
+): FluentProperty<[A, B, C]>
+
+/**
+ * Create a property test with four arbitraries.
+ * 
+ * @param arb1 - First arbitrary
+ * @param arb2 - Second arbitrary
+ * @param arb3 - Third arbitrary
+ * @param arb4 - Fourth arbitrary
+ * @param predicate - A function that returns true if the property holds
+ * @returns A `FluentProperty` that can be checked or asserted
+ */
+export function prop<A, B, C, D>(
+  arb1: Arbitrary<A>,
+  arb2: Arbitrary<B>,
+  arb3: Arbitrary<C>,
+  arb4: Arbitrary<D>,
+  predicate: (a: A, b: B, c: C, d: D) => boolean
+): FluentProperty<[A, B, C, D]>
+
+/**
+ * Create a property test with five arbitraries.
+ * 
+ * @param arb1 - First arbitrary
+ * @param arb2 - Second arbitrary
+ * @param arb3 - Third arbitrary
+ * @param arb4 - Fourth arbitrary
+ * @param arb5 - Fifth arbitrary
+ * @param predicate - A function that returns true if the property holds
+ * @returns A `FluentProperty` that can be checked or asserted
+ */
+export function prop<A, B, C, D, E>(
+  arb1: Arbitrary<A>,
+  arb2: Arbitrary<B>,
+  arb3: Arbitrary<C>,
+  arb4: Arbitrary<D>,
+  arb5: Arbitrary<E>,
+  predicate: (a: A, b: B, c: C, d: D, e: E) => boolean
+): FluentProperty<[A, B, C, D, E]>
+
+// Implementation
+export function prop(...args: unknown[]): FluentProperty<unknown[]> {
+  const predicate = args[args.length - 1] as (...args: unknown[]) => boolean
+  const arbitraries = args.slice(0, -1) as Arbitrary<unknown>[]
+  return new FluentPropertyImpl(arbitraries, predicate)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ import {FluentCheck, pre, PreconditionFailure} from './FluentCheck.js'
 import {FluentStrategyFactory} from './strategies/FluentStrategyFactory.js'
 export {expect} from './FluentReporter.js'
 export {pre, PreconditionFailure}
+export {prop} from './FluentProperty.js'
+export type {FluentProperty} from './FluentProperty.js'
 export const scenario = () => new FluentCheck()
 export const strategy = () => new FluentStrategyFactory()
 export {

--- a/test/prop-shorthand.test.ts
+++ b/test/prop-shorthand.test.ts
@@ -1,0 +1,164 @@
+import * as fc from '../src/index.js'
+import {it, describe} from 'mocha'
+import * as chai from 'chai'
+const {expect} = chai
+
+describe('prop() shorthand', () => {
+  describe('single arbitrary', () => {
+    it('should check property with single arbitrary', () => {
+      fc.prop(fc.integer(), x => x + 0 === x).check().assertSatisfiable()
+    })
+
+    it('should find counterexample for failing property', () => {
+      fc.prop(fc.integer(-100, 100), x => x > 0).check().assertNotSatisfiable()
+    })
+
+    it('should assert without throwing for valid property', () => {
+      fc.prop(fc.integer(), x => x + 0 === x).assert()
+    })
+
+    it('should throw when asserting failing property', () => {
+      expect(() => {
+        fc.prop(fc.integer(-100, 100), x => x > 1000).assert()
+      }).to.throw(/Property failed with counterexample/)
+    })
+
+    it('should include custom message in error', () => {
+      expect(() => {
+        fc.prop(fc.integer(-100, 100), x => x > 1000).assert('Custom message')
+      }).to.throw(/Custom message/)
+    })
+  })
+
+  describe('two arbitraries', () => {
+    it('should check commutativity of addition', () => {
+      fc.prop(fc.integer(), fc.integer(), (a, b) => a + b === b + a).check().assertSatisfiable()
+    })
+
+    it('should check associativity of addition', () => {
+      fc.prop(fc.integer(-1000, 1000), fc.integer(-1000, 1000), 
+        (a, b) => (a + b) - b === a
+      ).check().assertSatisfiable()
+    })
+
+    it('should find counterexample with two arbitraries', () => {
+      fc.prop(fc.integer(1, 10), fc.integer(1, 10), 
+        (a, b) => a === b
+      ).check().assertNotSatisfiable()
+    })
+  })
+
+  describe('three arbitraries', () => {
+    it('should check associativity of addition with three values', () => {
+      fc.prop(
+        fc.integer(-100, 100),
+        fc.integer(-100, 100),
+        fc.integer(-100, 100),
+        (a, b, c) => (a + b) + c === a + (b + c)
+      ).check().assertSatisfiable()
+    })
+  })
+
+  describe('four arbitraries', () => {
+    it('should check property with four values', () => {
+      fc.prop(
+        fc.integer(1, 10),
+        fc.integer(1, 10),
+        fc.integer(1, 10),
+        fc.integer(1, 10),
+        (a, b, c, d) => a + b + c + d >= 4
+      ).check().assertSatisfiable()
+    })
+  })
+
+  describe('five arbitraries', () => {
+    it('should check property with five values', () => {
+      fc.prop(
+        fc.integer(0, 10),
+        fc.integer(0, 10),
+        fc.integer(0, 10),
+        fc.integer(0, 10),
+        fc.integer(0, 10),
+        (a, b, c, d, e) => a + b + c + d + e >= 0
+      ).check().assertSatisfiable()
+    })
+  })
+
+  describe('with configuration', () => {
+    it('should use custom strategy', () => {
+      fc.prop(fc.integer(), x => x + 0 === x)
+        .config(fc.strategy().defaultStrategy())
+        .check()
+        .assertSatisfiable()
+    })
+
+    it('should chain config with assert', () => {
+      fc.prop(fc.integer(), x => x + 0 === x)
+        .config(fc.strategy().defaultStrategy())
+        .assert()
+    })
+
+    it('should use strategy with shrinking', () => {
+      // Property fails - there are negative integers
+      fc.prop(fc.integer(-100, 100), x => x >= 0)
+        .config(fc.strategy().withRandomSampling().withShrinking())
+        .check()
+        .assertNotSatisfiable()
+    })
+  })
+
+  describe('with different arbitrary types', () => {
+    it('should work with string arbitrary', () => {
+      fc.prop(fc.string(0, 10), s => s.length >= 0).check().assertSatisfiable()
+    })
+
+    it('should work with boolean arbitrary', () => {
+      fc.prop(fc.boolean(), b => b === true || b === false).check().assertSatisfiable()
+    })
+
+    it('should work with array arbitrary', () => {
+      fc.prop(
+        fc.array(fc.integer(0, 10), 0, 5),
+        arr => Array.isArray(arr)
+      ).check().assertSatisfiable()
+    })
+
+    it('should work with mixed arbitrary types', () => {
+      fc.prop(
+        fc.integer(),
+        fc.string(0, 5),
+        fc.boolean(),
+        (n, s, b) => typeof n === 'number' && typeof s === 'string' && typeof b === 'boolean'
+      ).check().assertSatisfiable()
+    })
+  })
+
+  describe('error messages', () => {
+    it('should include counterexample in error message', () => {
+      try {
+        fc.prop(fc.constant(42), x => x !== 42).assert()
+        expect.fail('Should have thrown')
+      } catch (e) {
+        expect((e as Error).message).to.include('42')
+      }
+    })
+
+    it('should include seed in error message', () => {
+      try {
+        fc.prop(fc.constant(1), x => x !== 1).assert()
+        expect.fail('Should have thrown')
+      } catch (e) {
+        expect((e as Error).message).to.include('seed')
+      }
+    })
+
+    it('should format multiple arguments in error', () => {
+      try {
+        fc.prop(fc.constant(1), fc.constant(2), (a, b) => a + b !== 3).assert()
+        expect.fail('Should have thrown')
+      } catch (e) {
+        expect((e as Error).message).to.include('(1, 2)')
+      }
+    })
+  })
+})

--- a/test/types/prop-shorthand.types.ts
+++ b/test/types/prop-shorthand.types.ts
@@ -1,0 +1,142 @@
+/**
+ * Type-level tests for fc.prop() shorthand API.
+ *
+ * These tests verify that type inference works correctly for all overloads
+ * of the prop() function and that the FluentProperty interface is correctly typed.
+ *
+ * Run with: npx tsc --noEmit
+ *
+ * If any type assertion fails, TypeScript will produce a compile error.
+ */
+
+import {prop, FluentProperty} from '../../src/FluentProperty.js'
+import {integer, string, boolean, array} from '../../src/arbitraries/index.js'
+
+// ============================================================================
+// Type assertion utilities (standard type-testing pattern)
+// ============================================================================
+
+/**
+ * Requires T to be `true`. If T is `false`, this causes a compile error.
+ */
+type Expect<T extends true> = T
+
+/**
+ * Returns `true` if X and Y are exactly equal types, `false` otherwise.
+ * Uses the distributive conditional type trick for exact equality.
+ */
+type Equal<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends (<T>() => T extends Y ? 1 : 2)
+    ? true
+    : false
+
+// ============================================================================
+// Test: Single arbitrary - predicate receives correct type
+// ============================================================================
+
+const singleArb = prop(integer(0, 100), x => x >= 0)
+type _T1 = Expect<Equal<typeof singleArb, FluentProperty<[number]>>>
+
+// Verify predicate parameter type is inferred correctly (should compile)
+prop(integer(), (x: number) => x + 0 === x)
+prop(string(), (s: string) => s.length >= 0)
+prop(boolean(), (b: boolean) => b === true || b === false)
+
+// ============================================================================
+// Test: Two arbitraries - predicate receives correct types
+// ============================================================================
+
+const twoArbs = prop(integer(), string(), (n, s) => String(n).length <= s.length || true)
+type _T2 = Expect<Equal<typeof twoArbs, FluentProperty<[number, string]>>>
+
+// Verify predicate parameter types are inferred correctly
+prop(integer(), boolean(), (a: number, b: boolean) => a > 0 || b)
+
+// ============================================================================
+// Test: Three arbitraries - predicate receives correct types
+// ============================================================================
+
+const threeArbs = prop(
+  integer(),
+  string(),
+  boolean(),
+  (n, s, b) => (b ? n.toString() : s).length >= 0
+)
+type _T3 = Expect<Equal<typeof threeArbs, FluentProperty<[number, string, boolean]>>>
+
+// ============================================================================
+// Test: Four arbitraries - predicate receives correct types
+// ============================================================================
+
+const fourArbs = prop(
+  integer(),
+  string(),
+  boolean(),
+  array(integer(), 0, 5),
+  (n, s, b, arr) => arr.includes(n) || !b || s.length >= 0
+)
+type _T4 = Expect<Equal<typeof fourArbs, FluentProperty<[number, string, boolean, number[]]>>>
+
+// ============================================================================
+// Test: Five arbitraries - predicate receives correct types
+// ============================================================================
+
+const fiveArbs = prop(
+  integer(0, 10),
+  integer(0, 10),
+  integer(0, 10),
+  integer(0, 10),
+  integer(0, 10),
+  (a, b, c, d, e) => a + b + c + d + e >= 0
+)
+type _T5 = Expect<Equal<typeof fiveArbs, FluentProperty<[number, number, number, number, number]>>>
+
+// ============================================================================
+// Test: config() returns FluentProperty with same type parameter
+// ============================================================================
+
+import {strategy} from '../../src/index.js'
+
+const configured = prop(integer(), x => x >= 0).config(strategy())
+type _T6 = Expect<Equal<typeof configured, FluentProperty<[number]>>>
+
+// Chained config
+const chainedConfig = prop(integer(), string(), (n, s) => true)
+  .config(strategy())
+type _T7 = Expect<Equal<typeof chainedConfig, FluentProperty<[number, string]>>>
+
+// ============================================================================
+// Test: check() returns FluentResult
+// ============================================================================
+
+import {FluentResult} from '../../src/FluentCheck.js'
+
+const checkResult = prop(integer(), x => x >= 0).check()
+type _T8 = Expect<Equal<typeof checkResult, FluentResult<Record<string, unknown>>>>
+
+// ============================================================================
+// Test: assert() returns void
+// ============================================================================
+
+const assertResult = prop(integer(), x => x + 0 === x).assert()
+type _T9 = Expect<Equal<typeof assertResult, void>>
+
+// ============================================================================
+// Test: Predicate with explicit return type
+// ============================================================================
+
+// Predicate must return boolean
+prop(integer(), (x): boolean => x >= 0)
+
+// ============================================================================
+// Test: @ts-expect-error - verify type errors are caught
+// ============================================================================
+
+// @ts-expect-error: Predicate should receive number, not string
+prop(integer(), (x: string) => x.length > 0)
+
+// @ts-expect-error: Predicate should receive (number, string), not (string, number)
+prop(integer(), string(), (a: string, b: number) => true)
+
+// @ts-expect-error: Wrong number of predicate arguments
+prop(integer(), string(), (a: number) => a > 0)


### PR DESCRIPTION
## Summary

- Adds `fc.prop()` as a simplified entry point for property testing
- Supports 1-5 arbitraries with positional parameters and full type inference
- Returns a `FluentProperty` interface with `check()`, `assert()`, and `config()` methods
- Reduces verbosity by 80% for simple properties (5 LOC → 1 LOC)

**Proposal:** openspec/changes/add-prop-shorthand/proposal.md
**Closes:** #406

## Examples

```typescript
// Single arbitrary
fc.prop(fc.integer(), x => x + 0 === x).assert();

// Multiple arbitraries
fc.prop(fc.integer(), fc.integer(), (a, b) => a + b === b + a).assert();

// With configuration
fc.prop(fc.integer(), x => x > 0)
  .config(fc.strategy().defaultStrategy())
  .assert();

// Check without throwing
const result = fc.prop(fc.integer(), x => x >= 0).check();
```

## Test Plan

- [x] All existing tests pass (193 tests)
- [x] New unit tests for prop shorthand added
- [x] Type tests for all overloads added
- [x] JSDoc documentation added
- [x] README updated with examples