### PR TITLE
fix: resolve eslint errors and warnings

### DIFF
--- a/src/FluentCheck.ts
+++ b/src/FluentCheck.ts
@@ -84,7 +84,7 @@ export class FluentResult<Rec extends {} = {}> {
    */
   assertSatisfiable(message?: string): void {
     if (!this.satisfiable) {
-      const prefix = message ? `${message}: ` : ''
+      const prefix = message !== undefined && message !== '' ? `${message}: ` : ''
       const exampleStr = JSON.stringify(this.example)
       const seedStr = this.seed !== undefined ? ` (seed: ${this.seed})` : ''
       throw new Error(`${prefix}Expected property to be satisfiable, but found counterexample: ${exampleStr}${seedStr}`)
@@ -109,7 +109,7 @@ export class FluentResult<Rec extends {} = {}> {
    */
   assertNotSatisfiable(message?: string): void {
     if (this.satisfiable) {
-      const prefix = message ? `${message}: ` : ''
+      const prefix = message !== undefined && message !== '' ? `${message}: ` : ''
       const exampleStr = JSON.stringify(this.example)
       const seedStr = this.seed !== undefined ? ` (seed: ${this.seed})` : ''
       throw new Error(`${prefix}Expected property to NOT be satisfiable, but found example: ${exampleStr}${seedStr}`)
@@ -149,7 +149,7 @@ export class FluentResult<Rec extends {} = {}> {
     }
 
     if (mismatches.length > 0) {
-      const prefix = message ? `${message}: ` : ''
+      const prefix = message !== undefined && message !== '' ? `${message}: ` : ''
       const seedStr = this.seed !== undefined ? ` (seed: ${this.seed})` : ''
       throw new Error(`${prefix}Example mismatch - ${mismatches.join('; ')}${seedStr}`)
     }
@@ -213,7 +213,9 @@ export class FluentCheck<Rec extends ParentRec, ParentRec extends {}> {
    * .given('count', 42)
    * ```
    */
-  given<K extends string, V>(name: K, v: NoInfer<V> | ((args: Rec) => V)): FluentCheckGiven<K, V, Rec & Record<K, V>, Rec> {
+  given<K extends string, V>(
+    name: K, v: NoInfer<V> | ((args: Rec) => V)
+  ): FluentCheckGiven<K, V, Rec & Record<K, V>, Rec> {
     return v instanceof Function ?
       new FluentCheckGivenMutable(this, name, v, this.strategy) :
       new FluentCheckGivenConstant<K, V, Rec & Record<K, V>, Rec>(this, name, v, this.strategy)
@@ -250,7 +252,9 @@ export class FluentCheck<Rec extends ParentRec, ParentRec extends {}> {
     return this.parent !== undefined ? [...this.parent.pathFromRoot(), this] : [this]
   }
 
-  check(child: (testCase: WrapFluentPick<any>) => FluentResult<Record<string, unknown>> = () => new FluentResult(true)): FluentResult<Rec> {
+  check(
+    child: (testCase: WrapFluentPick<any>) => FluentResult<Record<string, unknown>> = () => new FluentResult(true)
+  ): FluentResult<Rec> {
     if (this.parent !== undefined) return this.parent.check(testCase => this.run(testCase, child)) as FluentResult<Rec>
     else {
       this.strategy.randomGenerator.initialize()

--- a/src/FluentProperty.ts
+++ b/src/FluentProperty.ts
@@ -4,17 +4,17 @@ import {FluentStrategyFactory} from './strategies/FluentStrategyFactory.js'
 
 /**
  * A fluent property test builder that provides a simplified API for property-based testing.
- * 
+ *
  * @typeParam Args - Tuple type of the generated values from arbitraries
- * 
+ *
  * @example
  * ```typescript
  * // Single arbitrary
  * fc.prop(fc.integer(), x => x + 0 === x).assert();
- * 
+ *
  * // Multiple arbitraries
  * fc.prop(fc.integer(), fc.integer(), (a, b) => a + b === b + a).assert();
- * 
+ *
  * // With configuration
  * fc.prop(fc.integer(), x => x > 0)
  *   .config(fc.strategy().withShrinking())
@@ -24,9 +24,9 @@ import {FluentStrategyFactory} from './strategies/FluentStrategyFactory.js'
 export interface FluentProperty<Args extends unknown[]> {
   /**
    * Check the property and return a result without throwing.
-   * 
+   *
    * @returns A `FluentResult` containing the test outcome and any counterexample found
-   * 
+   *
    * @example
    * ```typescript
    * const result = fc.prop(fc.integer(), x => x >= 0).check();
@@ -39,15 +39,15 @@ export interface FluentProperty<Args extends unknown[]> {
 
   /**
    * Check the property and throw an error if it fails.
-   * 
+   *
    * @param message - Optional custom message prefix for the error
    * @throws Error if the property is not satisfiable, with a descriptive message including the counterexample
-   * 
+   *
    * @example
    * ```typescript
    * // Basic assertion
    * fc.prop(fc.integer(), x => x + 0 === x).assert();
-   * 
+   *
    * // With custom message
    * fc.prop(fc.integer(), x => x > 0).assert('Integer should be positive');
    * ```
@@ -56,10 +56,10 @@ export interface FluentProperty<Args extends unknown[]> {
 
   /**
    * Configure the property with a custom strategy.
-   * 
+   *
    * @param strategyFactory - A strategy factory to configure test execution
    * @returns A new `FluentProperty` with the configured strategy
-   * 
+   *
    * @example
    * ```typescript
    * fc.prop(fc.integer(), x => x > 0)
@@ -82,14 +82,15 @@ class FluentPropertyImpl<Args extends unknown[]> implements FluentProperty<Args>
 
   check(): FluentResult<Record<string, unknown>> {
     let checker = new FluentCheck()
-    
-    if (this.strategyFactory) {
+
+    if (this.strategyFactory !== undefined) {
       checker = checker.config(this.strategyFactory)
     }
 
     // Build the chain with positional argument names
-    let chain: FluentCheck<Record<string, unknown>, Record<string, unknown>> = checker as FluentCheck<Record<string, unknown>, Record<string, unknown>>
-    
+    let chain: FluentCheck<Record<string, unknown>, Record<string, unknown>> =
+      checker as FluentCheck<Record<string, unknown>, Record<string, unknown>>
+
     for (let i = 0; i < this.arbitraries.length; i++) {
       chain = chain.forall(`arg${i}`, this.arbitraries[i])
     }
@@ -106,11 +107,11 @@ class FluentPropertyImpl<Args extends unknown[]> implements FluentProperty<Args>
   assert(message?: string): void {
     const result = this.check()
     if (!result.satisfiable) {
-      const prefix = message ? `${message}: ` : ''
+      const prefix = message !== undefined && message !== '' ? `${message}: ` : ''
       // Extract positional arguments for cleaner error message
       const args = this.arbitraries.map((_, i) => result.example[`arg${i}`])
-      const argsStr = args.length === 1 
-        ? JSON.stringify(args[0]) 
+      const argsStr = args.length === 1
+        ? JSON.stringify(args[0])
         : `(${args.map(a => JSON.stringify(a)).join(', ')})`
       const seedStr = result.seed !== undefined ? ` (seed: ${result.seed})` : ''
       throw new Error(`${prefix}Property failed with counterexample: ${argsStr}${seedStr}`)
@@ -126,11 +127,11 @@ class FluentPropertyImpl<Args extends unknown[]> implements FluentProperty<Args>
 
 /**
  * Create a property test with a single arbitrary.
- * 
+ *
  * @param arb - The arbitrary to generate test values
  * @param predicate - A function that returns true if the property holds
  * @returns A `FluentProperty` that can be checked or asserted
- * 
+ *
  * @example
  * ```typescript
  * fc.prop(fc.integer(), x => x + 0 === x).assert();
@@ -143,12 +144,12 @@ export function prop<A>(
 
 /**
  * Create a property test with two arbitraries.
- * 
+ *
  * @param arb1 - First arbitrary
  * @param arb2 - Second arbitrary
  * @param predicate - A function that returns true if the property holds
  * @returns A `FluentProperty` that can be checked or asserted
- * 
+ *
  * @example
  * ```typescript
  * fc.prop(fc.integer(), fc.integer(), (a, b) => a + b === b + a).assert();
@@ -162,16 +163,16 @@ export function prop<A, B>(
 
 /**
  * Create a property test with three arbitraries.
- * 
+ *
  * @param arb1 - First arbitrary
  * @param arb2 - Second arbitrary
  * @param arb3 - Third arbitrary
  * @param predicate - A function that returns true if the property holds
  * @returns A `FluentProperty` that can be checked or asserted
- * 
+ *
  * @example
  * ```typescript
- * fc.prop(fc.integer(), fc.integer(), fc.integer(), 
+ * fc.prop(fc.integer(), fc.integer(), fc.integer(),
  *   (a, b, c) => (a + b) + c === a + (b + c)
  * ).assert();
  * ```
@@ -185,7 +186,7 @@ export function prop<A, B, C>(
 
 /**
  * Create a property test with four arbitraries.
- * 
+ *
  * @param arb1 - First arbitrary
  * @param arb2 - Second arbitrary
  * @param arb3 - Third arbitrary
@@ -203,7 +204,7 @@ export function prop<A, B, C, D>(
 
 /**
  * Create a property test with five arbitraries.
- * 
+ *
  * @param arb1 - First arbitrary
  * @param arb2 - Second arbitrary
  * @param arb3 - Third arbitrary

--- a/src/arbitraries/ArbitraryComposite.ts
+++ b/src/arbitraries/ArbitraryComposite.ts
@@ -1,6 +1,6 @@
 import {Arbitrary} from './internal.js'
 import {ArbitrarySize, FluentPick} from './types.js'
-import {exactSize, estimatedSize, NilArbitrarySize} from './util.js'
+import {exactSize, estimatedSize} from './util.js'
 import * as fc from './index.js'
 
 export class ArbitraryComposite<A> extends Arbitrary<A> {
@@ -27,7 +27,8 @@ export class ArbitraryComposite<A> extends Arbitrary<A> {
       (acc, a) => { acc.push((acc.at(-1) ?? 0) + a.size().value); return acc },
       new Array<number>()
     )
-    const picked = Math.floor(generator() * weights.at(-1)!)
+    const lastWeight = weights.at(-1)
+    const picked = Math.floor(generator() * (lastWeight ?? 0))
     return this.arbitraries[weights.findIndex(s => s > picked)].pick(generator)
   }
 

--- a/src/arbitraries/FilteredArbitrary.ts
+++ b/src/arbitraries/FilteredArbitrary.ts
@@ -1,7 +1,7 @@
 import {BetaDistribution} from '../statistics.js'
 import {EstimatedSize, FluentPick} from './types.js'
 import {Arbitrary, NoArbitrary, WrappedArbitrary} from './internal.js'
-import {estimatedSize, lowerCredibleInterval, mapArbitrarySize, upperCredibleInterval} from './util.js'
+import {estimatedSize, lowerCredibleInterval, upperCredibleInterval} from './util.js'
 
 export class FilteredArbitrary<A> extends WrappedArbitrary<A> {
   sizeEstimation: BetaDistribution

--- a/src/arbitraries/datetime.ts
+++ b/src/arbitraries/datetime.ts
@@ -1,4 +1,4 @@
-import {Arbitrary, ArbitraryInteger, NoArbitrary} from './internal.js'
+import {Arbitrary, NoArbitrary} from './internal.js'
 import {tuple, integer} from './index.js'
 
 /**

--- a/src/arbitraries/util.ts
+++ b/src/arbitraries/util.ts
@@ -17,7 +17,10 @@ export function mapArbitrarySize(sz: ArbitrarySize, f: (v: number) => ArbitraryS
   if (sz.type === 'exact' && result.type === 'exact') {
     return exactSize(result.value)
   }
-  return estimatedSize(result.value, result.type === 'estimated' ? result.credibleInterval : [result.value, result.value])
+  const interval = result.type === 'estimated'
+    ? result.credibleInterval
+    : [result.value, result.value] as [number, number]
+  return estimatedSize(result.value, interval)
 }
 
 export function stringify(object: any) {

--- a/src/strategies/FluentStrategyMixins.ts
+++ b/src/strategies/FluentStrategyMixins.ts
@@ -1,50 +1,11 @@
-import {Arbitrary, FluentPick} from '../arbitraries/index.js'
-import {FluentResult} from '../FluentCheck.js'
+import type {Arbitrary, FluentPick} from '../arbitraries/index.js'
+import type {FluentResult} from '../FluentCheck.js'
 import {FluentStrategy, FluentStrategyInterface} from './FluentStrategy.js'
-
-// Interface to properly type the arbitrary structure used in the strategy
-interface ArbitraryContainer<A> {
-  arbitrary: Arbitrary<A>;
-  collection: FluentPick<A>[];
-  pickNum: number;
-  cache?: FluentPick<A>[];
-}
-
-// Interface to describe the configuration properties
-interface StrategyConfiguration {
-  sampleSize: number;
-  shrinkSize: number;
-}
 
 // Define a constructor type for use with mixins
 type MixinConstructor<T = {}> = new (...args: any[]) => T
 // Define a base type for the strategy constructor
 type MixinStrategy = MixinConstructor<FluentStrategy>
-
-// Base class with the common properties to be used by the mixins
-// Note: This abstract class documents the expected interface for mixin targets
-abstract class _MixinBase {
-  arbitraries: Record<string, ArbitraryContainer<any>> = {}
-  configuration: StrategyConfiguration = {
-    sampleSize: 100,
-    shrinkSize: 100
-  }
-  randomGenerator: { generator: () => number } = {
-    generator: () => Math.random()
-  }
-
-  buildArbitraryCollection<A>(_arbitrary: Arbitrary<A>, _sampleSize?: number): FluentPick<A>[] {
-    throw new Error('Method not implemented', {
-      cause: 'Mixin method requires implementation'
-    })
-  }
-
-  isDedupable(): boolean {
-    throw new Error('Method not implemented', {
-      cause: 'Mixin method requires implementation'
-    })
-  }
-}
 
 export function Random<TBase extends MixinStrategy>(Base: TBase) {
   return class extends Base implements FluentStrategyInterface {
@@ -66,7 +27,7 @@ export function Shrinkable<TBase extends MixinStrategy>(Base: TBase) {
     shrink<K extends string>(arbitraryName: K, partial: FluentResult<Record<string, unknown>>) {
       const shrinkedArbitrary = this.arbitraries[arbitraryName].arbitrary.shrink(partial.example[arbitraryName])
       this.arbitraries[arbitraryName].collection = this.buildArbitraryCollection(shrinkedArbitrary,
-        this.configuration.shrinkSize!)
+        this.configuration.shrinkSize)
     }
   }
 }
@@ -90,8 +51,9 @@ export function Cached<TBase extends MixinStrategy>(Base: TBase) {
 export function Biased<TBase extends MixinStrategy>(Base: TBase) {
   return class extends Base {
     buildArbitraryCollection<A>(arbitrary: Arbitrary<A>, sampleSize = this.configuration.sampleSize): FluentPick<A>[] {
-      return this.isDedupable() ? arbitrary.sampleUniqueWithBias(sampleSize!, this.randomGenerator.generator) :
-        arbitrary.sampleWithBias(sampleSize!, this.randomGenerator.generator)
+      return this.isDedupable()
+        ? arbitrary.sampleUniqueWithBias(sampleSize, this.randomGenerator.generator)
+        : arbitrary.sampleWithBias(sampleSize, this.randomGenerator.generator)
     }
   }
 }

--- a/test/presets.test.ts
+++ b/test/presets.test.ts
@@ -445,7 +445,10 @@ describe('Arbitrary Presets', () => {
         .then(({rgb}) => {
           const [r, g, b] = rgb
           // Valid RGB components
-          const hex = `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`
+          const rHex = r.toString(16).padStart(2, '0')
+          const gHex = g.toString(16).padStart(2, '0')
+          const bHex = b.toString(16).padStart(2, '0')
+          const hex = `#${rHex}${gHex}${bHex}`
           return /^#[0-9a-f]{6}$/.test(hex)
         })
         .check()

--- a/test/prop-shorthand.test.ts
+++ b/test/prop-shorthand.test.ts
@@ -36,13 +36,13 @@ describe('prop() shorthand', () => {
     })
 
     it('should check associativity of addition', () => {
-      fc.prop(fc.integer(-1000, 1000), fc.integer(-1000, 1000), 
+      fc.prop(fc.integer(-1000, 1000), fc.integer(-1000, 1000),
         (a, b) => (a + b) - b === a
       ).check().assertSatisfiable()
     })
 
     it('should find counterexample with two arbitraries', () => {
-      fc.prop(fc.integer(1, 10), fc.integer(1, 10), 
+      fc.prop(fc.integer(1, 10), fc.integer(1, 10),
         (a, b) => a === b
       ).check().assertNotSatisfiable()
     })

--- a/test/regex.test.ts
+++ b/test/regex.test.ts
@@ -135,8 +135,7 @@ describe('Regex tests', () => {
       .forall('email', fc.patterns.email())
       .then(({email}) => {
         // An email must contain exactly one @ symbol
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- typescript-eslint incorrectly infers `any`; tsc correctly sees `string`
-        return email.includes('@') && email.includes('.')
+        return String(email).includes('@') && String(email).includes('.')
       })
       .check()
     ).to.have.property('satisfiable', true)

--- a/test/types/const-type-params.types.ts
+++ b/test/types/const-type-params.types.ts
@@ -9,6 +9,8 @@
  * If any type assertion fails, TypeScript will produce a compile error.
  */
 
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
 import {oneof, set, tuple, integer, boolean, Arbitrary} from '../../src/arbitraries/index.js'
 
 // ============================================================================

--- a/test/types/discriminated-unions.types.ts
+++ b/test/types/discriminated-unions.types.ts
@@ -9,6 +9,8 @@
  * If any type assertion fails, TypeScript will produce a compile error.
  */
 
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
 import {
   ArbitrarySize,
   ExactSize,
@@ -112,10 +114,11 @@ function exhaustiveSwitch(size: ArbitrarySize): string {
       return `Exactly ${size.value}`
     case 'estimated':
       return `~${size.value} (${size.credibleInterval[0]}-${size.credibleInterval[1]})`
-    default:
+    default: {
       // This ensures exhaustiveness - if a new variant is added, this will error
       const _exhaustive: never = size
       return _exhaustive
+    }
   }
 }
 

--- a/test/types/fluentresult.types.ts
+++ b/test/types/fluentresult.types.ts
@@ -9,6 +9,8 @@
  * If any type assertion fails, TypeScript will produce a compile error.
  */
 
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
 import {FluentCheck, FluentResult} from '../../src/FluentCheck.js'
 import * as fc from '../../src/arbitraries/index.js'
 

--- a/test/types/noinfer.types.ts
+++ b/test/types/noinfer.types.ts
@@ -9,6 +9,8 @@
  * If any type assertion fails, TypeScript will produce a compile error.
  */
 
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
 import {FluentCheck} from '../../src/FluentCheck.js'
 import {integer, Arbitrary} from '../../src/arbitraries/index.js'
 

--- a/test/types/prop-shorthand.types.ts
+++ b/test/types/prop-shorthand.types.ts
@@ -9,6 +9,8 @@
  * If any type assertion fails, TypeScript will produce a compile error.
  */
 
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
 import {prop, FluentProperty} from '../../src/FluentProperty.js'
 import {integer, string, boolean, array} from '../../src/arbitraries/index.js'
 


### PR DESCRIPTION
## Summary
- Fix all 6 eslint errors and 134 warnings across the codebase
- Ensure strict-boolean-expressions compliance for nullable strings
- Remove unused imports, variables, and code
- Add eslint-disable comments for type test files where unused vars are expected

## Test plan
- [x] Run `npm run lint` - passes with 0 errors/warnings
- [x] Run `npm test` - all 261 tests pass