### PR TITLE
refactor: add explicit override keyword to overridden methods

### DIFF
--- a/openspec/changes/ts-modernise-override/tasks.md
+++ b/openspec/changes/ts-modernise-override/tasks.md
@@ -1,16 +1,16 @@
 ## 1. Implementation
 
-- [ ] 1.1 Add `override` keyword to `ArbitraryInteger` methods
-- [ ] 1.2 Add `override` keyword to `ArbitraryReal` methods
-- [ ] 1.3 Add `override` keyword to `ArbitraryBoolean` methods
-- [ ] 1.4 Add `override` keyword to `ArbitraryArray` methods
-- [ ] 1.5 Add `override` keyword to `ArbitrarySet` methods
-- [ ] 1.6 Add `override` keyword to `ArbitraryTuple` methods
-- [ ] 1.7 Add `override` keyword to `ArbitraryComposite` methods
-- [ ] 1.8 Add `override` keyword to `ArbitraryConstant` methods
-- [ ] 1.9 Add `override` keyword to `MappedArbitrary` methods
-- [ ] 1.10 Add `override` keyword to `FilteredArbitrary` methods
-- [ ] 1.11 Add `override` keyword to `ChainedArbitrary` methods
-- [ ] 1.12 Add `override` keyword to `WrappedArbitrary` methods
-- [ ] 1.13 Add `override` keyword to `FluentCheck` subclass methods
-- [ ] 1.14 Run full test suite to ensure no regressions
+- [x] 1.1 Add `override` keyword to `ArbitraryInteger` methods
+- [x] 1.2 Add `override` keyword to `ArbitraryReal` methods
+- [x] 1.3 Add `override` keyword to `ArbitraryBoolean` methods
+- [x] 1.4 Add `override` keyword to `ArbitraryArray` methods
+- [x] 1.5 Add `override` keyword to `ArbitrarySet` methods
+- [x] 1.6 Add `override` keyword to `ArbitraryTuple` methods
+- [x] 1.7 Add `override` keyword to `ArbitraryComposite` methods
+- [x] 1.8 Add `override` keyword to `ArbitraryConstant` methods
+- [x] 1.9 Add `override` keyword to `MappedArbitrary` methods
+- [x] 1.10 Add `override` keyword to `FilteredArbitrary` methods
+- [x] 1.11 Add `override` keyword to `ChainedArbitrary` methods
+- [x] 1.12 Add `override` keyword to `WrappedArbitrary` methods
+- [x] 1.13 Add `override` keyword to `FluentCheck` subclass methods
+- [x] 1.14 Run full test suite to ensure no regressions

--- a/src/FluentCheck.ts
+++ b/src/FluentCheck.ts
@@ -337,7 +337,7 @@ class FluentCheckGivenConstant<K extends string, V, Rec extends ParentRec & Reco
     super(parent, name, strategy)
   }
 
-  protected run(testCase: Rec, callback: (arg: Rec) => FluentResult) {
+  protected override run(testCase: Rec, callback: (arg: Rec) => FluentResult) {
     (testCase as Record<string, V>)[this.name] = this.value
     return callback(testCase)
   }
@@ -356,7 +356,7 @@ abstract class FluentCheckQuantifier<K extends string, A, Rec extends ParentRec 
     this.strategy.addArbitrary(this.name, a)
   }
 
-  protected run(
+  protected override run(
     testCase: WrapFluentPick<Rec>,
     callback: (arg: WrapFluentPick<Rec>) => FluentResult,
     partial: FluentResult | undefined = undefined,
@@ -424,7 +424,7 @@ class FluentCheckAssert<Rec extends ParentRec, ParentRec extends {}> extends Flu
     return data as Rec
   }
 
-  protected run(testCase: WrapFluentPick<Rec>,
+  protected override run(testCase: WrapFluentPick<Rec>,
     callback: (arg: WrapFluentPick<Rec>) => FluentResult): FluentResult {
     const unwrappedTestCase = FluentCheck.unwrapFluentPick(testCase)
     try {

--- a/src/arbitraries/ArbitraryArray.ts
+++ b/src/arbitraries/ArbitraryArray.ts
@@ -8,7 +8,7 @@ export class ArbitraryArray<A> extends Arbitrary<A[]> {
     super()
   }
 
-  size() {
+  override size() {
     // https://en.wikipedia.org/wiki/Geometric_progression#Geometric_series
     const sizeUpTo = (v: number, max: number) => {
       return v === 1 ? max + 1 : (1 - v ** (max + 1)) / (1 - v)
@@ -19,7 +19,7 @@ export class ArbitraryArray<A> extends Arbitrary<A[]> {
     })
   }
 
-  pick(generator: () => number): FluentPick<A[]> | undefined {
+  override pick(generator: () => number): FluentPick<A[]> | undefined {
     const size = Math.floor(generator() * (this.max - this.min + 1)) + this.min
     const fpa = this.arbitrary.sample(size)
 
@@ -32,7 +32,7 @@ export class ArbitraryArray<A> extends Arbitrary<A[]> {
     }
   }
 
-  shrink(initial: FluentPick<A[]>): Arbitrary<A[]> {
+  override shrink(initial: FluentPick<A[]>): Arbitrary<A[]> {
     if (this.min === initial.value.length) return fc.empty()
 
     const start = this.min
@@ -42,19 +42,19 @@ export class ArbitraryArray<A> extends Arbitrary<A[]> {
     return fc.union(fc.array(this.arbitrary, start, middle), fc.array(this.arbitrary, middle + 1, end))
   }
 
-  canGenerate(pick: FluentPick<A[]>) {
+  override canGenerate(pick: FluentPick<A[]>) {
     return pick.value.length >= this.min && pick.value.length <= this.max &&
            pick.value.every((v, i) => this.arbitrary.canGenerate({value: v, original: pick.original[i]}))
   }
 
-  cornerCases(): FluentPick<A[]>[] {
+  override cornerCases(): FluentPick<A[]>[] {
     return this.arbitrary.cornerCases().flatMap(cc => [
       {value: Array(this.min).fill(cc.value), original: Array(this.min).fill(cc.original)},
       {value: Array(this.max).fill(cc.value), original: Array(this.max).fill(cc.original)}
     ]).filter(v => v !== undefined) as FluentPick<A[]>[]
   }
 
-  toString(depth = 0): string {
+  override toString(depth = 0): string {
     return ' '.repeat(depth * 2) +
       `Array Arbitrary: min = ${this.min} max = ${this.max}\n${this.arbitrary.toString(depth + 1)}`
   }

--- a/src/arbitraries/ArbitraryBoolean.ts
+++ b/src/arbitraries/ArbitraryBoolean.ts
@@ -4,7 +4,7 @@ import * as fc from './index.js'
 
 export class ArbitraryBoolean extends MappedArbitrary<number, boolean> {
   constructor() { super(fc.integer(0, 1), x => x === 0) }
-  shrink(_: FluentPick<boolean>) { return NoArbitrary }
-  canGenerate(pick: FluentPick<boolean>) { return pick.value !== undefined }
-  toString(depth = 0) { return ' '.repeat(2 * depth) + 'Boolean Arbitrary' }
+  override shrink(_: FluentPick<boolean>) { return NoArbitrary }
+  override canGenerate(pick: FluentPick<boolean>) { return pick.value !== undefined }
+  override toString(depth = 0) { return ' '.repeat(2 * depth) + 'Boolean Arbitrary' }
 }

--- a/src/arbitraries/ArbitraryComposite.ts
+++ b/src/arbitraries/ArbitraryComposite.ts
@@ -8,7 +8,7 @@ export class ArbitraryComposite<A> extends Arbitrary<A> {
     super()
   }
 
-  size(): ArbitrarySize {
+  override size(): ArbitrarySize {
     let value = 0
     let isEstimated = false
 
@@ -22,7 +22,7 @@ export class ArbitraryComposite<A> extends Arbitrary<A> {
     return isEstimated ? estimatedSize(value, [value, value]) : exactSize(value)
   }
 
-  pick(generator: () => number) {
+  override pick(generator: () => number) {
     const weights = this.arbitraries.reduce(
       (acc, a) => { acc.push((acc.at(-1) ?? 0) + a.size().value); return acc },
       new Array<number>()
@@ -32,20 +32,20 @@ export class ArbitraryComposite<A> extends Arbitrary<A> {
     return this.arbitraries[weights.findIndex(s => s > picked)].pick(generator)
   }
 
-  cornerCases(): FluentPick<A>[] {
+  override cornerCases(): FluentPick<A>[] {
     return this.arbitraries.flatMap(a => a.cornerCases())
   }
 
-  shrink(initial: FluentPick<A>) {
+  override shrink(initial: FluentPick<A>) {
     const arbitraries = this.arbitraries.filter(a => a.canGenerate(initial)).map(a => a.shrink(initial))
     return fc.union(...arbitraries)
   }
 
-  canGenerate(pick: FluentPick<A>) {
+  override canGenerate(pick: FluentPick<A>) {
     return this.arbitraries.some(a => a.canGenerate(pick))
   }
 
-  toString(depth = 0) {
+  override toString(depth = 0) {
     return ' '.repeat(2 * depth) +
       'Composite Arbitrary:\n' + this.arbitraries.map(a => a.toString(depth + 1)).join('\n')
   }

--- a/src/arbitraries/ArbitraryConstant.ts
+++ b/src/arbitraries/ArbitraryConstant.ts
@@ -7,11 +7,11 @@ export class ArbitraryConstant<A> extends Arbitrary<A> {
     super()
   }
 
-  size(): ExactSize { return exactSize(1) }
-  pick(): FluentPick<A> { return {value: this.constant, original: this.constant} }
-  cornerCases() { return [this.pick()] }
-  canGenerate(pick: FluentPick<A>) {
+  override size(): ExactSize { return exactSize(1) }
+  override pick(): FluentPick<A> { return {value: this.constant, original: this.constant} }
+  override cornerCases() { return [this.pick()] }
+  override canGenerate(pick: FluentPick<A>) {
     return pick.value === this.constant
   }
-  toString(depth = 0): string { return ' '.repeat(depth * 2) + `Constant Arbitrary: ${this.constant}` }
+  override toString(depth = 0): string { return ' '.repeat(depth * 2) + `Constant Arbitrary: ${this.constant}` }
 }

--- a/src/arbitraries/ArbitraryInteger.ts
+++ b/src/arbitraries/ArbitraryInteger.ts
@@ -8,16 +8,16 @@ export class ArbitraryInteger extends Arbitrary<number> {
     super()
   }
 
-  size(): ExactSize {
+  override size(): ExactSize {
     return exactSize(this.max - this.min + 1)
   }
 
-  pick(generator: () => number) {
+  override pick(generator: () => number) {
     const value = Math.floor(generator() * (this.max - this.min + 1)) + this.min
     return {value, original: value}
   }
 
-  cornerCases() {
+  override cornerCases() {
     const middle = Math.round((this.min + this.max) / 2)
     const ccs = [... new Set(this.min < 0 && this.max > 0 ?
       [0, this.min, middle, this.max] : [this.min, middle, this.max])]
@@ -26,7 +26,7 @@ export class ArbitraryInteger extends Arbitrary<number> {
     return ccs.map(value => ({value, original: value}))
   }
 
-  shrink(initial: FluentPick<number>): Arbitrary<number> {
+  override shrink(initial: FluentPick<number>): Arbitrary<number> {
     if (initial.value > 0) {
       const lower = Math.max(0, this.min)
       const upper = initial.value - 1
@@ -46,9 +46,9 @@ export class ArbitraryInteger extends Arbitrary<number> {
     return NoArbitrary
   }
 
-  canGenerate(pick: FluentPick<number>) {
+  override canGenerate(pick: FluentPick<number>) {
     return pick.value >= this.min && pick.value <= this.max
   }
 
-  toString(depth = 0) { return ' '.repeat(depth * 2) + `Integer Arbitrary: min = ${this.min} max = ${this.max}` }
+  override toString(depth = 0) { return ' '.repeat(depth * 2) + `Integer Arbitrary: min = ${this.min} max = ${this.max}` }
 }

--- a/src/arbitraries/ArbitraryReal.ts
+++ b/src/arbitraries/ArbitraryReal.ts
@@ -5,7 +5,7 @@ export class ArbitraryReal extends ArbitraryInteger {
     super(min, max)
   }
 
-  pick(generator: () => number)  {
+  override pick(generator: () => number)  {
     const value = generator() * (this.max - this.min) + this.min
     return {value, original: value}
   }

--- a/src/arbitraries/ArbitrarySet.ts
+++ b/src/arbitraries/ArbitrarySet.ts
@@ -12,7 +12,7 @@ export class ArbitrarySet<A> extends Arbitrary<A[]> {
     this.max = Math.min(max, elements.length)
   }
 
-  size(): ExactSize {
+  override size(): ExactSize {
     const comb = (n: number, s: number) => { return factorial (n) / (factorial(s) * factorial(n - s)) }
 
     let value = 0
@@ -21,7 +21,7 @@ export class ArbitrarySet<A> extends Arbitrary<A[]> {
     return exactSize(value)
   }
 
-  pick(generator: () => number): FluentPick<A[]> | undefined {
+  override pick(generator: () => number): FluentPick<A[]> | undefined {
     const size = Math.floor(generator() * (this.max - this.min + 1)) + this.min
     const pick = new Set<A>()
 
@@ -33,7 +33,7 @@ export class ArbitrarySet<A> extends Arbitrary<A[]> {
     return {value, original: value}
   }
 
-  shrink(initial: FluentPick<A[]>): Arbitrary<A[]> {
+  override shrink(initial: FluentPick<A[]>): Arbitrary<A[]> {
     if (this.min === initial.value.length) return fc.empty()
 
     const start = this.min
@@ -43,12 +43,12 @@ export class ArbitrarySet<A> extends Arbitrary<A[]> {
     return fc.union(fc.set(this.elements, start, middle), fc.set(this.elements, middle + 1, end))
   }
 
-  canGenerate(pick: FluentPick<A[]>) {
+  override canGenerate(pick: FluentPick<A[]>) {
     return pick.value.length >= this.min && pick.value.length <= this.max &&
            pick.value.every(v => this.elements.includes(v))
   }
 
-  cornerCases(): FluentPick<A[]>[] {
+  override cornerCases(): FluentPick<A[]>[] {
     const min: A[] = []
     for (let i = 0; i < this.min; i++) min.push(this.elements[i])
 
@@ -58,7 +58,7 @@ export class ArbitrarySet<A> extends Arbitrary<A[]> {
     return [{value: min, original: min}, {value: max, original: max}]
   }
 
-  toString(depth = 0) {
+  override toString(depth = 0) {
     return ' '.repeat(depth * 2) +
       `Set Arbitrary: min = ${this.min} max = ${this.max} elements = [${this.elements.join(', ')}]`
   }

--- a/src/arbitraries/ArbitraryTuple.ts
+++ b/src/arbitraries/ArbitraryTuple.ts
@@ -10,7 +10,7 @@ export class ArbitraryTuple<U extends Arbitrary<any>[], A = UnwrapArbitrary<U>> 
     super()
   }
 
-  size(): ArbitrarySize {
+  override size(): ArbitrarySize {
     let value = 1
     let isEstimated = false
 
@@ -24,7 +24,7 @@ export class ArbitraryTuple<U extends Arbitrary<any>[], A = UnwrapArbitrary<U>> 
     return isEstimated ? estimatedSize(value, [value, value]) : exactSize(value)
   }
 
-  pick(generator: () => number): FluentPick<A> | undefined {
+  override pick(generator: () => number): FluentPick<A> | undefined {
     const value: any = []
     const original: any[] = []
 
@@ -40,7 +40,7 @@ export class ArbitraryTuple<U extends Arbitrary<any>[], A = UnwrapArbitrary<U>> 
     return {value, original}
   }
 
-  cornerCases(): FluentPick<A>[] {
+  override cornerCases(): FluentPick<A>[] {
     const cornerCases = this.arbitraries.map(a => a.cornerCases())
 
     return cornerCases.reduce((acc, cc) => acc.flatMap(a => cc.map(b => ({
@@ -49,7 +49,7 @@ export class ArbitraryTuple<U extends Arbitrary<any>[], A = UnwrapArbitrary<U>> 
     }))), [{value: [], original: []}])
   }
 
-  shrink(initial: FluentPick<A>): Arbitrary<A> {
+  override shrink(initial: FluentPick<A>): Arbitrary<A> {
     const value = initial.value as unknown[]
     const original = initial.original as unknown[]
     return fc.union(...this.arbitraries.map((_, selected) =>
@@ -60,7 +60,7 @@ export class ArbitraryTuple<U extends Arbitrary<any>[], A = UnwrapArbitrary<U>> 
       )))) as Arbitrary<A>
   }
 
-  canGenerate(pick: FluentPick<A>): boolean {
+  override canGenerate(pick: FluentPick<A>): boolean {
     const value = pick.value as unknown[]
     const original = pick.original as unknown[]
     for (const i in value) {
@@ -72,7 +72,7 @@ export class ArbitraryTuple<U extends Arbitrary<any>[], A = UnwrapArbitrary<U>> 
     return true
   }
 
-  toString(depth = 0) {
+  override toString(depth = 0) {
     return ' '.repeat(2 * depth) +
       'Tuple Arbitrary:\n' + this.arbitraries.map(a => a.toString(depth + 1)).join('\n')
   }

--- a/src/arbitraries/ChainedArbitrary.ts
+++ b/src/arbitraries/ChainedArbitrary.ts
@@ -6,22 +6,22 @@ export class ChainedArbitrary<A, B> extends Arbitrary<B> {
     super()
   }
 
-  size() { return this.baseArbitrary.size() }
+  override size() { return this.baseArbitrary.size() }
 
-  pick(generator: () => number): FluentPick<B> | undefined {
+  override pick(generator: () => number): FluentPick<B> | undefined {
     const pick = this.baseArbitrary.pick(generator)
     return pick === undefined ? undefined : this.f(pick.value).pick(generator)
   }
 
-  cornerCases(): FluentPick<B>[] {
+  override cornerCases(): FluentPick<B>[] {
     return this.baseArbitrary.cornerCases().flatMap(p => this.f(p.value).cornerCases())
   }
 
-  canGenerate<B>(_: FluentPick<B>): boolean {
+  override canGenerate<B>(_: FluentPick<B>): boolean {
     return true
   }
 
-  toString(depth = 0) {
+  override toString(depth = 0) {
     return ' '.repeat(depth * 2) +
       `Chained Arbitrary: f = ${this.f.toString()}\n` + this.baseArbitrary.toString(depth + 1)
   }

--- a/src/arbitraries/FilteredArbitrary.ts
+++ b/src/arbitraries/FilteredArbitrary.ts
@@ -11,7 +11,7 @@ export class FilteredArbitrary<A> extends WrappedArbitrary<A> {
     this.sizeEstimation = new BetaDistribution(2, 1) // use 1,1 for .mean instead of .mode in point estimation
   }
 
-  size(): EstimatedSize {
+  override size(): EstimatedSize {
     // TODO: Still not sure if we should use mode or mean for estimating the size (depends on which error we are trying
     // to minimize, L1 or L2)
     // Also, this assumes we estimate a continuous interval between 0 and 1;
@@ -28,7 +28,7 @@ export class FilteredArbitrary<A> extends WrappedArbitrary<A> {
     )
   }
 
-  pick(generator: () => number): FluentPick<A> | undefined {
+  override pick(generator: () => number): FluentPick<A> | undefined {
     do {
       const pick = this.baseArbitrary.pick(generator)
       if (pick === undefined) break // TODO: update size estimation accordingly
@@ -40,18 +40,18 @@ export class FilteredArbitrary<A> extends WrappedArbitrary<A> {
     return undefined
   }
 
-  cornerCases() { return this.baseArbitrary.cornerCases().filter(a => this.f(a.value)) }
+  override cornerCases() { return this.baseArbitrary.cornerCases().filter(a => this.f(a.value)) }
 
-  shrink(initialValue: FluentPick<A>) {
+  override shrink(initialValue: FluentPick<A>) {
     if (!this.f(initialValue.value)) return NoArbitrary
     return this.baseArbitrary.shrink(initialValue).filter(v => this.f(v))
   }
 
-  canGenerate(pick: FluentPick<A>) {
+  override canGenerate(pick: FluentPick<A>) {
     return this.baseArbitrary.canGenerate(pick) && this.f(pick.value)
   }
 
-  toString(depth = 0) {
+  override toString(depth = 0) {
     return ' '.repeat(depth * 2) +
       `Filtered Arbitrary: f = ${this.f.toString()}\n` + this.baseArbitrary.toString(depth + 1)
   }

--- a/src/arbitraries/MappedArbitrary.ts
+++ b/src/arbitraries/MappedArbitrary.ts
@@ -17,7 +17,7 @@ export class MappedArbitrary<A, B> extends Arbitrary<B> {
     return {value: this.f(p.value), original}
   }
 
-  pick(generator: () => number): FluentPick<B> | undefined {
+  override pick(generator: () => number): FluentPick<B> | undefined {
     const pick = this.baseArbitrary.pick(generator)
     return pick !== undefined ? this.mapFluentPick(pick) : undefined
   }
@@ -27,23 +27,23 @@ export class MappedArbitrary<A, B> extends Arbitrary<B> {
   // small arbitraries), or use a cardinality estimator such as HyperLogLog for big ones. One
   // interesting information we could leverage here is that the new arbitrary size will never
   // be *above* the baseArbitrary.
-  size() { return this.baseArbitrary.size() }
+  override size() { return this.baseArbitrary.size() }
 
-  cornerCases(): FluentPick<B>[] {
+  override cornerCases(): FluentPick<B>[] {
     return this.baseArbitrary.cornerCases().map(p => this.mapFluentPick(p))
   }
 
-  shrink(initial: FluentPick<B>): Arbitrary<B> {
+  override shrink(initial: FluentPick<B>): Arbitrary<B> {
     return this.baseArbitrary.shrink({value: initial.original, original: initial.original}).map(v => this.f(v))
   }
 
-  canGenerate(pick: FluentPick<B>) {
+  override canGenerate(pick: FluentPick<B>) {
     const inverseValues = this.shrinkHelper !== undefined && this.shrinkHelper.inverseMap !== undefined ?
       this.shrinkHelper.inverseMap(pick.value) : [pick.original]
     return inverseValues.some(value => this.baseArbitrary.canGenerate({value, original: pick.original}))
   }
 
-  toString(depth = 0) {
+  override toString(depth = 0) {
     return ' '.repeat(2 * depth) +
       `Map Arbitrary: f = ${this.f.toString()}\n` + this.baseArbitrary.toString(depth + 1)
   }

--- a/src/arbitraries/WrappedArbitrary.ts
+++ b/src/arbitraries/WrappedArbitrary.ts
@@ -6,15 +6,15 @@ export abstract class WrappedArbitrary<A> extends Arbitrary<A> {
     super()
   }
 
-  pick(generator: () => number) { return this.baseArbitrary.pick(generator) }
-  size() { return this.baseArbitrary.size() }
-  cornerCases() { return this.baseArbitrary.cornerCases() }
+  override pick(generator: () => number) { return this.baseArbitrary.pick(generator) }
+  override size() { return this.baseArbitrary.size() }
+  override cornerCases() { return this.baseArbitrary.cornerCases() }
 
-  canGenerate(pick: FluentPick<A>) {
+  override canGenerate(pick: FluentPick<A>) {
     return this.baseArbitrary.canGenerate(pick)
   }
 
-  toString(depth = 0) {
+  override toString(depth = 0) {
     return ' '.repeat(depth * 2) +
       'Wrapped Arbitrary:\n' + this.baseArbitrary.toString(depth + 1)
   }


### PR DESCRIPTION
## Summary

Implements openspec change proposal for adding explicit `override` keyword to overridden methods.

- Add `override` keyword to all methods that override parent class methods
- Enables compile-time safety for refactoring parent classes
- Affects all Arbitrary subclasses and FluentCheck subclasses

**Proposal:** openspec/changes/ts-modernise-override/proposal.md
**Closes:** #381

## Tasks

See `openspec/changes/ts-modernise-override/tasks.md` for implementation checklist.

## Test Plan

- [x] All existing tests pass (261 passing)
- [x] New tests added for changed behavior (N/A - no behavior change)
- [x] `openspec validate ts-modernise-override --strict` passes