### PR TITLE
feat: add reproducibility features (path tracking, replay, regression examples)

### DIFF
--- a/openspec/changes/add-reproducibility/proposal.md
+++ b/openspec/changes/add-reproducibility/proposal.md
@@ -1,0 +1,171 @@
+# Change: Add Reproducibility Features
+
+> **GitHub Issue:** [#431](https://github.com/fluent-check/fluent-check/issues/431)
+
+## Why
+
+When a property-based test fails, developers need to:
+1. **Reproduce** the exact failure reliably (beyond just seed)
+2. **Add regression tests** to prevent the bug from recurring
+3. **Debug** complex test scenarios by understanding the generation path
+
+Currently, FluentCheck captures the seed in results and error messages, but this is insufficient for full reproducibility. As noted in GitHub issue #430, we are missing:
+- The concept of a **path** (like fast-check) to navigate to specific test cases in the generation tree
+- The ability to add known **counterexamples as regression tests** that always run
+- A way to **replay** exact test sequences for debugging
+
+## What Changes
+
+- Add `path` tracking to capture the sequence of choices during value generation
+- Add `replay({ seed, path? })` method to reproduce exact test cases
+- Add `withExample(example)` and `withExamples(examples[])` methods for regression testing
+- Enhance `FluentResult` to include `path` alongside `seed`
+- Add verbose/debug mode for tracing test execution
+
+## Code Examples
+
+### Example 1: Capturing and Replaying a Failure
+
+```typescript
+// Original failing test
+const result = fc.scenario()
+  .forall('x', fc.integer())
+  .forall('y', fc.integer())
+  .then(({ x, y }) => x + y === y + x + 1)  // Bug: always fails
+  .check()
+
+// Result includes reproducibility info:
+// result.satisfiable === false
+// result.seed === 1234567890
+// result.path === "42:7"  // x was sample 42, y was sample 7
+// result.example === { x: -5, y: 3 }
+
+// Error message includes replay hint:
+// "Expected property to be satisfiable, but found counterexample: {"x":-5,"y":3}
+//  (seed: 1234567890, path: "42:7")
+//  Replay with: .replay({ seed: 1234567890, path: "42:7" })"
+```
+
+### Example 2: Replay for Debugging
+
+```typescript
+// Replay exact failure for debugging
+fc.scenario()
+  .forall('x', fc.integer())
+  .forall('y', fc.integer())
+  .replay({ seed: 1234567890, path: '42:7' })  // Reproduce exact case
+  .then(({ x, y }) => {
+    console.log(`Testing x=${x}, y=${y}`)  // x=-5, y=3
+    return x + y === y + x + 1
+  })
+  .check()
+```
+
+### Example 3: Regression Examples (Fluent Composition)
+
+```typescript
+// Add specific examples that always get tested
+// Type inference ensures examples match the bound variables
+fc.scenario()
+  .forall('x', fc.integer())
+  .forall('y', fc.integer())
+  .withExample({ x: 0, y: 0 })           // Edge case: zeros
+  .withExample({ x: -1, y: 1 })          // Edge case: opposite signs
+  .withExample({ x: Number.MAX_SAFE_INTEGER, y: 1 })  // Boundary
+  .then(({ x, y }) => x + y === y + x)
+  .check()
+  .assertSatisfiable()
+
+// Or batch add with withExamples()
+fc.scenario()
+  .forall('x', fc.integer())
+  .forall('y', fc.integer())
+  .withExamples([
+    { x: 0, y: 0 },
+    { x: -1, y: 1 },
+    { x: Number.MAX_SAFE_INTEGER, y: 1 }
+  ])
+  .then(({ x, y }) => x + y === y + x)
+  .check()
+```
+
+### Example 4: Partial Examples
+
+```typescript
+// Provide only some variables, others are randomly generated
+fc.scenario()
+  .forall('a', fc.integer())
+  .forall('b', fc.integer())
+  .forall('c', fc.integer())
+  .withExample({ a: 0 })  // Only fix 'a', 'b' and 'c' are random
+  .then(({ a, b, c }) => a * (b + c) === a * b + a * c)
+  .check()
+```
+
+### Example 5: Verbose Mode for Debugging
+
+```typescript
+fc.scenario()
+  .forall('x', fc.integer(-10, 10))
+  .forall('y', fc.integer(-10, 10))
+  .verbose()  // Enable debug output
+  .then(({ x, y }) => x * y >= 0)  // Fails for mixed signs
+  .check()
+
+// Console output:
+// [fluent-check] Test case 1: { x: 5, y: 3 } (path: "0:0") ✓
+// [fluent-check] Test case 2: { x: -2, y: 7 } (path: "1:1") ✗
+// [fluent-check] Shrinking from { x: -2, y: 7 }...
+// [fluent-check] Shrink step 1: { x: -1, y: 7 } (path: "1:1;s1") ✗
+// [fluent-check] Shrink step 2: { x: -1, y: 1 } (path: "1:1;s2") ✗
+// [fluent-check] Minimal counterexample: { x: -1, y: 1 }
+```
+
+## Path Format Design
+
+In FluentCheck, the generation path tracks the sample index for each quantified variable:
+
+```
+path = "<index1>:<index2>:...[:s<shrinkDepth>]"
+```
+
+**Components:**
+- `<indexN>` - The sample index used for the Nth quantifier (in declaration order)
+- `:s<depth>` - Optional suffix indicating shrinking depth
+
+**Examples:**
+| Scenario | Path | Meaning |
+|----------|------|---------|
+| Single variable, first sample | `"0"` | First sample for the only quantifier |
+| Two variables | `"42:7"` | 42nd sample for first var, 7th for second |
+| After 3 shrink steps | `"42:7:s3"` | Original at 42:7, shrunk 3 times |
+| Three variables | `"10:20:30"` | Indices for x, y, z in order |
+
+**How it works internally:**
+
+```typescript
+// During generation, track pickNum for each arbitrary
+// arbitraries['x'].pickNum = 42  -> path starts with "42"
+// arbitraries['y'].pickNum = 7   -> path becomes "42:7"
+
+// During shrinking, increment depth counter
+// shrinkDepth = 3 -> path becomes "42:7:s3"
+```
+
+**Replay follows the path:**
+
+```typescript
+// When replay({ seed: 1234, path: "42:7" }) is called:
+// 1. Initialize RNG with seed 1234
+// 2. Generate samples as normal
+// 3. Instead of iterating, jump directly to:
+//    - arbitraries['x'].collection[42]
+//    - arbitraries['y'].collection[7]
+// 4. Execute the test with those specific values
+```
+
+## Impact
+
+- Affected specs: `fluent-api`, `random-generation`, `reporting`
+- Affected code: `FluentCheck.ts`, `FluentStrategy.ts`, `FluentResult`, `FluentRandomGenerator`
+- No breaking changes - all features are additive

--- a/openspec/changes/add-reproducibility/specs/fluent-api/spec.md
+++ b/openspec/changes/add-reproducibility/specs/fluent-api/spec.md
@@ -1,0 +1,99 @@
+## ADDED Requirements
+
+### Requirement: Replay Configuration
+
+The system SHALL provide a `replay({ seed, path? })` method to reproduce specific test cases.
+
+#### Scenario: Replay with seed and path
+- **WHEN** `.replay({ seed: 12345, path: "42:3" })` is called
+- **THEN** the test SHALL generate the exact same inputs that produced the original failure
+- **AND** no random generation SHALL occur beyond following the recorded path
+
+#### Scenario: Replay with seed only
+- **WHEN** `.replay({ seed: 12345 })` is called without a path
+- **THEN** the test SHALL use the seed to initialize the random generator
+- **AND** random generation SHALL proceed normally from that seed
+
+#### Scenario: Invalid replay parameters
+- **WHEN** `.replay({})` is called without a seed
+- **THEN** an error SHALL be thrown indicating seed is required
+
+#### Scenario: Replay after quantifiers
+- **WHEN** `.replay()` is called after `.forall()` or `.exists()` quantifiers
+- **THEN** the replay configuration SHALL apply to test execution
+- **AND** the method SHALL return a chainable instance for further configuration
+
+### Requirement: Regression Example (Singular)
+
+The system SHALL provide a `withExample(example)` method to add a single regression test case with fluent composition.
+
+#### Scenario: Single example fluent chain
+- **WHEN** `.forall('x', fc.integer()).withExample({ x: 0 })` is called
+- **THEN** the provided example SHALL be tested before random generation
+- **AND** the method SHALL return a chainable instance
+
+#### Scenario: Multiple examples via chaining
+- **WHEN** `.withExample({ x: 0 }).withExample({ x: -1 }).withExample({ x: 100 })` is called
+- **THEN** all three examples SHALL be tested in order
+- **AND** random generation SHALL only occur if all examples pass
+
+#### Scenario: Type inference from scenario
+- **GIVEN** a scenario with `.forall('x', fc.integer()).forall('y', fc.string())`
+- **WHEN** `.withExample(example)` is called
+- **THEN** the `example` parameter SHALL be typed as `Partial<{ x: number, y: string }>`
+- **AND** TypeScript SHALL report errors for incorrect property types
+- **AND** TypeScript SHALL report errors for unknown property names
+
+#### Scenario: Example after then clause
+- **WHEN** `.forall('x', fc.integer()).then(pred).withExample({ x: 5 })` is written
+- **THEN** the example SHALL still be type-checked against bound variables
+- **AND** the example SHALL be tested before random generation
+
+### Requirement: Regression Examples (Batch)
+
+The system SHALL provide a `withExamples(examples[])` method to add multiple regression test cases at once.
+
+#### Scenario: Batch examples
+- **WHEN** `.withExamples([{ x: 0, y: 0 }, { x: -1, y: 1 }])` is called
+- **THEN** all provided examples SHALL be tested in array order
+- **AND** random generation SHALL only occur if all examples pass
+
+#### Scenario: Partial examples in batch
+- **WHEN** `.withExamples([{ x: 5 }, { y: "test" }])` is called on a scenario with variables `x` and `y`
+- **THEN** each example SHALL provide only the specified variables
+- **AND** unspecified variables SHALL be randomly generated
+
+#### Scenario: Type-safe batch examples
+- **GIVEN** a scenario with `.forall('x', fc.integer())`
+- **WHEN** `.withExamples([{ x: "not a number" }])` is written
+- **THEN** TypeScript SHALL report a type error at compile time
+
+#### Scenario: Empty examples array
+- **WHEN** `.withExamples([])` is called
+- **THEN** no regression examples SHALL be tested
+- **AND** random generation SHALL proceed normally
+
+### Requirement: Verbose Mode
+
+The system SHALL provide a `verbose(options?)` method to enable debug output during test execution.
+
+#### Scenario: Enable verbose mode
+- **WHEN** `.verbose()` is called
+- **THEN** the test SHALL log each generated test case to the console
+- **AND** shrinking steps SHALL be logged when finding minimal counterexamples
+
+#### Scenario: Verbose with custom logger
+- **WHEN** `.verbose({ logger: customFn })` is called
+- **THEN** debug output SHALL be sent to the custom logger function
+- **AND** the default console logger SHALL not be used
+
+#### Scenario: Verbose output format
+- **WHEN** verbose mode is enabled
+- **THEN** each logged test case SHALL include its generation path
+- **AND** pass/fail status SHALL be indicated with ✓ or ✗ symbols
+- **AND** shrinking steps SHALL be prefixed with "Shrink step N:"
+
+#### Scenario: Verbose output includes replay info
+- **WHEN** a counterexample is found in verbose mode
+- **THEN** the output SHALL include the seed and path
+- **AND** the output SHALL suggest the `replay()` call to reproduce

--- a/openspec/changes/add-reproducibility/specs/random-generation/spec.md
+++ b/openspec/changes/add-reproducibility/specs/random-generation/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: Path Tracking
+
+The system SHALL track a generation path representing the sequence of choices made during test case generation.
+
+#### Scenario: Path format
+- **WHEN** a test runs and generates values
+- **THEN** the path SHALL be a colon-separated string of sample indices (e.g., `"42:7:3"`)
+- **AND** each index corresponds to a quantifier in declaration order
+
+#### Scenario: Path recorded during generation
+- **WHEN** the strategy iterates through test cases
+- **THEN** each `pickNum` value SHALL be captured for the path
+- **AND** the complete path SHALL uniquely identify a test case given the same seed
+
+#### Scenario: Path with shrinking
+- **WHEN** a counterexample is found and shrinking occurs
+- **THEN** the path SHALL be suffixed with `:s<depth>` (e.g., `"42:7:s3"`)
+- **AND** the shrink depth SHALL increment with each shrinking step
+
+#### Scenario: Path reset between test runs
+- **WHEN** `.check()` is called multiple times
+- **THEN** each run SHALL start with an empty path
+- **AND** paths from previous runs SHALL not affect current generation
+
+### Requirement: Path-Guided Generation
+
+The system SHALL support path-guided generation that follows a recorded path to reproduce specific test cases.
+
+#### Scenario: Follow recorded path
+- **WHEN** a path `"42:7"` is provided to `replay()`
+- **THEN** the first quantifier SHALL use its 42nd sample
+- **AND** the second quantifier SHALL use its 7th sample
+- **AND** no iteration over other samples SHALL occur
+
+#### Scenario: Path with shrink suffix
+- **WHEN** a path `"42:7:s3"` is provided to `replay()`
+- **THEN** generation SHALL start at indices 42 and 7
+- **AND** shrinking SHALL be performed 3 times from that point
+
+#### Scenario: Path exhaustion
+- **WHEN** the scenario has more quantifiers than path indices
+- **THEN** extra quantifiers SHALL use normal random generation
+- **AND** the extended path SHALL be recorded in the result
+
+#### Scenario: Path validation
+- **WHEN** a path index exceeds available samples (e.g., index 1000 with sampleSize 100)
+- **THEN** an error SHALL be thrown indicating invalid path
+- **AND** the error message SHALL include the problematic index and variable name
+
+#### Scenario: Malformed path
+- **WHEN** a path with invalid format is provided (e.g., `"abc:xyz"`)
+- **THEN** an error SHALL be thrown indicating path parse failure
+- **AND** the expected format SHALL be included in the error message

--- a/openspec/changes/add-reproducibility/specs/reporting/spec.md
+++ b/openspec/changes/add-reproducibility/specs/reporting/spec.md
@@ -1,0 +1,39 @@
+## MODIFIED Requirements
+
+### Requirement: FluentResult
+
+The system SHALL provide a `FluentResult` class containing test execution outcomes.
+
+#### Scenario: Success result
+- **WHEN** a property is satisfied
+- **THEN** `result.satisfiable` SHALL be `true`
+- **AND** `result.example` contains a satisfying example
+
+#### Scenario: Failure result
+- **WHEN** a property is not satisfied
+- **THEN** `result.satisfiable` SHALL be `false`
+- **AND** `result.example` contains the shrunk counterexample
+
+#### Scenario: Seed included
+- **WHEN** a test completes
+- **THEN** `result.seed` contains the seed used for reproduction
+
+#### Scenario: Path included
+- **WHEN** a test completes with a counterexample or example
+- **THEN** `result.path` SHALL contain the generation path as a string
+- **AND** the path format SHALL be `"<index1>:<index2>:...[:s<shrinkDepth>]"`
+
+#### Scenario: Replay hint in assertion errors
+- **WHEN** `assertSatisfiable()` throws an error
+- **THEN** the error message SHALL include both seed and path
+- **AND** the message SHALL include a replay suggestion like `.replay({ seed: N, path: "X:Y" })`
+
+#### Scenario: Path in assertNotSatisfiable errors
+- **WHEN** `assertNotSatisfiable()` throws an error
+- **THEN** the error message SHALL include seed and path for the found example
+- **AND** developers can use this to investigate why an example was found
+
+#### Scenario: Path in assertExample errors
+- **WHEN** `assertExample()` throws an error due to mismatch
+- **THEN** the error message SHALL include seed and path
+- **AND** the specific property mismatches SHALL be listed

--- a/openspec/changes/add-reproducibility/tasks.md
+++ b/openspec/changes/add-reproducibility/tasks.md
@@ -1,0 +1,50 @@
+# Tasks: Add Reproducibility Features
+
+## 1. Path Tracking Infrastructure
+- [ ] 1.1 Define `GenerationPath` type as string (e.g., `"42:7:s3"`)
+- [ ] 1.2 Add path building utilities: `parsePath()`, `formatPath()`
+- [ ] 1.3 Extend `FluentStrategy` to track `currentPath` during iteration
+- [ ] 1.4 Capture `pickNum` for each quantifier into path segments
+- [ ] 1.5 Track shrink depth and append `:s<depth>` suffix during shrinking
+- [ ] 1.6 Add unit tests for path format and parsing
+
+## 2. Enhanced FluentResult
+- [ ] 2.1 Add `path?: string` property to `FluentResult` class
+- [ ] 2.2 Update `check()` to capture and return path alongside seed
+- [ ] 2.3 Update `assertSatisfiable()` error message to include path and replay hint
+- [ ] 2.4 Update `assertNotSatisfiable()` error message to include path
+- [ ] 2.5 Update `assertExample()` error message to include path
+- [ ] 2.6 Add unit tests for path inclusion in all result scenarios
+
+## 3. Replay API
+- [ ] 3.1 Add `ReplayOptions` type: `{ seed: number, path?: string }`
+- [ ] 3.2 Add `replay(options: ReplayOptions)` method to `FluentCheck`
+- [ ] 3.3 Implement path-guided generation that jumps to specific sample indices
+- [ ] 3.4 Validate path indices don't exceed sample collection sizes
+- [ ] 3.5 Validate path format and throw descriptive errors for malformed paths
+- [ ] 3.6 Handle shrink suffix (`:sN`) to replay shrinking steps
+- [ ] 3.7 Add unit tests for exact reproduction via replay
+
+## 4. Regression Examples API
+- [ ] 4.1 Add `withExample<Rec>(example: Partial<Rec>)` method with proper type inference
+- [ ] 4.2 Add `withExamples<Rec>(examples: Partial<Rec>[])` method
+- [ ] 4.3 Store examples in strategy for injection before random generation
+- [ ] 4.4 Execute examples in order before random samples
+- [ ] 4.5 Ensure partial examples work: provided vars fixed, others random
+- [ ] 4.6 Ensure type inference flows from bound variables (forall/exists/given)
+- [ ] 4.7 Add compile-time type tests for incorrect example types
+- [ ] 4.8 Add unit tests for single example, multiple examples, partial examples
+
+## 5. Verbose/Debug Mode
+- [ ] 5.1 Add `VerboseOptions` type: `{ logger?: (msg: string) => void }`
+- [ ] 5.2 Add `verbose(options?: VerboseOptions)` method to `FluentCheck`
+- [ ] 5.3 Log each test case: `[fluent-check] Test case N: {...} (path: "...") ✓/✗`
+- [ ] 5.4 Log shrinking steps: `[fluent-check] Shrink step N: {...} (path: "...") ✓/✗`
+- [ ] 5.5 Log final counterexample with replay suggestion
+- [ ] 5.6 Support custom logger function
+- [ ] 5.7 Add unit tests for verbose output format
+
+## 6. Documentation & Integration
+- [ ] 6.1 Add JSDoc comments to `replay()`, `withExample()`, `withExamples()`, `verbose()`
+- [ ] 6.2 Update README with reproducibility section and examples
+- [ ] 6.3 Add example test file: `test/reproducibility.test.ts`


### PR DESCRIPTION
## Summary

Implements openspec change proposal for reproducibility features.

**Proposal:** openspec/changes/add-reproducibility/proposal.md
**Closes:** #431

### Key Features

- **Path tracking**: Capture generation path (e.g., `"42:7:s3"`) for exact test case identification
- **Replay API**: `.replay({ seed, path })` to reproduce exact failures
- **Regression examples**: `.withExample()` / `.withExamples()` for always-run test cases
- **Verbose mode**: `.verbose()` for debug output during test execution

### Code Examples

```typescript
// Replay a failure
fc.scenario()
  .forall('x', fc.integer())
  .replay({ seed: 1234567890, path: '42:7' })
  .then(({ x }) => x > 0)
  .check()

// Add regression examples (type-safe)
fc.scenario()
  .forall('x', fc.integer())
  .forall('y', fc.integer())
  .withExample({ x: 0, y: 0 })
  .withExample({ x: -1, y: 1 })
  .then(({ x, y }) => x + y === y + x)
  .check()
```

## Tasks

See `openspec/changes/add-reproducibility/tasks.md` for implementation checklist.

## Test Plan

- [ ] All existing tests pass
- [ ] New tests added for changed behavior
- [ ] `openspec validate add-reproducibility --strict` passes