### PR TITLE
chore: add pre-commit hooks and migrate tests to assertSatisfiable()

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+npm run lint
+npm test

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,7 +9,7 @@ export default tseslint.config(
     languageOptions: {
       globals: {
         ...globals.node,
-        ...globals.es2020,
+        ...globals.es2025,
       },
       parserOptions: {
         project: './tsconfig.eslint.json',
@@ -49,6 +49,7 @@ export default tseslint.config(
       '@typescript-eslint/no-non-null-assertion': 'warn',
       '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
       '@typescript-eslint/consistent-type-imports': ['warn', { prefer: 'type-imports', fixStyle: 'inline-type-imports' }],
+      '@typescript-eslint/no-unnecessary-type-assertion': 'warn',
 
       // Level 0 rules: disabled
       'no-console': 'off',

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "chai": "^6.2.1",
         "eslint": "^9.39.1",
         "globals": "^16.5.0",
+        "husky": "^9.1.7",
         "jstat": "^1.9.6",
         "mocha": "^11.7.5",
         "nyc": "^17.1.0",
@@ -2113,6 +2114,22 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
     },
     "node_modules/ignore": {
       "version": "7.0.5",
@@ -5354,6 +5371,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
       "dev": true
     },
     "ignore": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
   },
   "scripts": {
     "lint": "eslint src test",
+    "lint:fix": "eslint src test --fix",
     "test": "mocha",
-    "prepare": "tsc",
+    "prepare": "husky && tsc",
     "coverage": "nyc mocha -reporter=min -r source-map-support"
   },
   "keywords": [
@@ -43,6 +44,7 @@
     "chai": "^6.2.1",
     "eslint": "^9.39.1",
     "globals": "^16.5.0",
+    "husky": "^9.1.7",
     "jstat": "^1.9.6",
     "mocha": "^11.7.5",
     "nyc": "^17.1.0",

--- a/src/arbitraries/ArbitraryInteger.ts
+++ b/src/arbitraries/ArbitraryInteger.ts
@@ -50,5 +50,7 @@ export class ArbitraryInteger extends Arbitrary<number> {
     return pick.value >= this.min && pick.value <= this.max
   }
 
-  override toString(depth = 0) { return ' '.repeat(depth * 2) + `Integer Arbitrary: min = ${this.min} max = ${this.max}` }
+  override toString(depth = 0) {
+    return ' '.repeat(2 * depth) + `Integer Arbitrary: min = ${this.min} max = ${this.max}`
+  }
 }

--- a/src/arbitraries/presets.ts
+++ b/src/arbitraries/presets.ts
@@ -117,7 +117,7 @@ export const nonEmptyArray = <A>(arb: Arbitrary<A>, maxLength = 10): Arbitrary<A
  * ```
  */
 export const pair = <A>(arb: Arbitrary<A>): Arbitrary<[A, A]> =>
-  tuple(arb, arb) as Arbitrary<[A, A]>
+  tuple(arb, arb)
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Nullable/Optional Presets

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import {FluentCheck, pre, PreconditionFailure} from './FluentCheck.js'
 import {FluentStrategyFactory} from './strategies/FluentStrategyFactory.js'
-import type { ArbitrarySize } from './arbitraries/types.js'
 export {expect} from './FluentReporter.js'
 export {pre, PreconditionFailure}
 export {prop} from './FluentProperty.js'

--- a/test/arbitrary.test.ts
+++ b/test/arbitrary.test.ts
@@ -6,43 +6,43 @@ const {expect} = chai
 
 describe('Arbitrary tests', () => {
   it('should return has many numbers has asked', () => {
-    expect(fc.scenario()
+    fc.scenario()
       .forall('n', fc.integer(0, 100))
       .given('a', () => fc.integer())
       .then(({n, a}) => a.sample(n).length === n)
       .check()
-    ).to.have.property('satisfiable', true)
+      .assertSatisfiable()
   })
 
   it('should return values in the specified range', () => {
-    expect(fc.scenario()
+    fc.scenario()
       .forall('n', fc.integer(0, 100))
       .given('a', () => fc.integer(0, 50))
       .then(({n, a}) => a.sample(n).every(i => i.value <= 50))
       .and(({n, a}) => a.sampleWithBias(n).every(i => i.value <= 50))
       .check()
-    ).to.have.property('satisfiable', true)
+      .assertSatisfiable()
   })
 
   it('should return corner cases if there is space', () => {
-    expect(fc.scenario()
+    fc.scenario()
       .forall('n', fc.integer(4, 100))
       .given('a', () => fc.integer(0, 50))
       .then(({n, a}) => a.sampleWithBias(n).some(v => v.value === 0))
       .and(({n, a}) => a.sampleWithBias(n).some(v => v.value === 50))
       .check()
-    ).to.have.property('satisfiable', true)
+      .assertSatisfiable()
   })
 
   it('should return values smaller than what was shrunk', () => {
-    expect(fc.scenario()
+    fc.scenario()
       .forall('n', fc.integer(0, 100))
       .forall('s', fc.integer(0, 100))
       .given('a', () => fc.integer(0, 100))
       .then(({n, s, a}) => a.shrink({value: s}).sample(n).every(i => i.value < s))
       .and(({n, s, a}) => a.shrink({value: s}).sampleWithBias(n).every(i => i.value < s))
       .check()
-    ).to.have.property('satisfiable', true)
+      .assertSatisfiable()
   })
 
   it('should allow shrinking of mapped arbitraries', () => {
@@ -147,21 +147,21 @@ describe('Arbitrary tests', () => {
 
   describe('Transformations', () => {
     it('should allow booleans to be mappeable', () => {
-      expect(fc.scenario()
+      fc.scenario()
         .forall('n', fc.integer(10, 100))
         .given('a', () => fc.boolean().map(e => e ? 'Heads' : 'Tails'))
         .then(({a, n}) => a.sampleWithBias(n).some(s => s.value === 'Heads'))
         .and(({a, n}) => a.sampleWithBias(n).some(s => s.value === 'Tails'))
         .check()
-      ).to.have.property('satisfiable', true)
+        .assertSatisfiable()
     })
 
     it('should allow integers to be filtered', () => {
-      expect(fc.scenario()
+      fc.scenario()
         .forall('n', fc.integer(0, 100).filter(n => n < 10))
         .then(({n}) => n < 10)
         .check()
-      ).to.have.property('satisfiable', true)
+        .assertSatisfiable()
     })
 
     it('filters should exclude corner cases, even after shrinking', () => {
@@ -173,11 +173,11 @@ describe('Arbitrary tests', () => {
     })
 
     it('should allow integers to be both mapped and filtered', () => {
-      expect(fc.scenario()
+      fc.scenario()
         .forall('n', fc.integer(0, 100).map(n => n + 100).filter(n => n < 150))
         .then(({n}) => n >= 100 && n <= 150)
         .check()
-      ).to.have.property('satisfiable', true)
+        .assertSatisfiable()
     })
 
     describe('suchThat (filter alias)', () => {
@@ -289,8 +289,8 @@ describe('Arbitrary tests', () => {
       describe('EstimatedSize implementations', () => {
         it('filtered arbitrary returns EstimatedSize with credibleInterval', () => {
           const size = fc.integer(0, 100).filter(n => n > 50).size()
-          
-          // We are loosing type information here, because .filter should automatically 
+
+          // We are loosing type information here, because .filter should automatically
           // narrow the type back to an estimated size. See #438
           if (size.type === 'estimated') {
             expect(size.type).to.equal('estimated')
@@ -397,7 +397,7 @@ describe('Arbitrary tests', () => {
       it('size should be estimated for filtered arbitraries', () => {
         const size1 = fc.integer(1, 1000).filter(i => i > 200).filter(i => i < 800).size()
         expect(size1.type).to.equal('estimated')
-        // We are loosing type information here, because .filter should automatically 
+        // We are loosing type information here, because .filter should automatically
         // narrow the type back to an estimated size. See #438
         if (size1.type === 'estimated') {
           expect(size1.credibleInterval[0]).to.be.below(600)
@@ -408,7 +408,7 @@ describe('Arbitrary tests', () => {
 
         const size2 = fc.integer(1, 1000).filter(i => i > 200 && i < 800).size()
         expect(size2.type).to.equal('estimated')
-        // We are loosing type information here, because .filter should automatically 
+        // We are loosing type information here, because .filter should automatically
         // narrow the type back to an estimated size. See #438
         if (size2.type === 'estimated') {
           expect(size2.credibleInterval[0]).to.be.below(600)
@@ -493,16 +493,16 @@ describe('Arbitrary tests', () => {
     })
 
     it('should return no more than the number of possible cases', () => {
-      expect(fc.scenario()
+      fc.scenario()
         .forall('n', fc.integer(3, 10))
         .given('ub', () => fc.boolean())
         .then(({n, ub}) => ub.sampleUnique(n).length === 2)
         .check()
-      ).to.have.property('satisfiable', true)
+        .assertSatisfiable()
     })
 
     it('should return a unique sample with bias with corner cases', () => {
-      expect(fc.scenario()
+      fc.scenario()
         .forall('n', fc.integer(10, 20))
         .forall('s', fc.integer(5, 10))
         .given('a', ({n}) => fc.integer(0, n))
@@ -511,11 +511,11 @@ describe('Arbitrary tests', () => {
         .and(({r}) => r.length === new Set(r.map(e => e.value)).size)
         .and(({a, r}) => a.cornerCases().map(c => c.value).every(e => r.map(e => e.value).includes(e)))
         .check()
-      ).to.have.property('satisfiable', true)
+        .assertSatisfiable()
     })
 
     it('should return a unique sample with bias even with a small sample', () => {
-      expect(fc.scenario()
+      fc.scenario()
         .forall('n', fc.integer(10, 20))
         .forall('s', fc.integer(0, 5))
         .given('a', ({n}) => fc.integer(0, n))
@@ -523,7 +523,7 @@ describe('Arbitrary tests', () => {
         .then(({r, s}) => r.length === s)
         .and(({r}) => r.length === new Set(r.map(e => e.value)).size)
         .check()
-      ).to.have.property('satisfiable', true)
+        .assertSatisfiable()
     })
   })
 
@@ -535,12 +535,11 @@ describe('Arbitrary tests', () => {
     })
 
     it('should check a property based on a chained arbitrary', () => {
-      expect(
-        fc.scenario()
-          .forall('a', fc.integer(1, 10).chain(i => fc.array(fc.constant(i), i, i)))
-          .then(({a}) => a.length === a[0])
-          .check()
-      ).to.have.property('satisfiable', true)
+      fc.scenario()
+        .forall('a', fc.integer(1, 10).chain(i => fc.array(fc.constant(i), i, i)))
+        .then(({a}) => a.length === a[0])
+        .check()
+        .assertSatisfiable()
     })
   })
 
@@ -604,7 +603,7 @@ describe('Arbitrary tests', () => {
 
     it('knows if it can be generated by a set', () => {
       expect(fc.set(['a', 'b', 'c'], 1, 3) .canGenerate({value: ['a', 'b', 'c']})).to.be.true
-      
+
       // Type system does not allow this
       // expect(fc.set(['a', 'b', 'c'], 1, 3) .canGenerate({value: ['a', 'b', 'd']})).to.be.false
       expect(fc.set(['a', 'b', 'c'], 1, 2) .canGenerate({value: ['a', 'b', 'c']})).to.be.false
@@ -652,11 +651,11 @@ describe('Arbitrary tests', () => {
 
     it('should always be satisfiable due to vacuous truth in universal assertions', () => {
       /* istanbul ignore next */
-      expect(fc.scenario()
+      fc.scenario()
         .forall('empty', fc.empty())
         .then(_ => false)
         .check()
-      ).to.have.property('satisfiable', true)
+        .assertSatisfiable()
     })
 
     it('should never be satisfiable due to vacuous truth in existential assertions', () => {

--- a/test/datetime.test.ts
+++ b/test/datetime.test.ts
@@ -1,23 +1,22 @@
 import * as fc from '../src/index'
 import {it, describe} from 'mocha'
-import {expect} from 'chai'
 
 describe('DateTime tests', () => {
   it('should generate dates in the specified range', () => {
     const MIN_DATE = new Date('2020-01-01')
     const MAX_DATE = new Date('2020-12-31')
 
-    expect(fc.scenario()
+    fc.scenario()
       .forall('d', fc.date(MIN_DATE, MAX_DATE))
       .then(({d}) => {
         return d >= MIN_DATE && d <= MAX_DATE
       })
       .check()
-    ).to.have.property('satisfiable', true)
+      .assertSatisfiable()
   })
 
   it('should generate valid time objects', () => {
-    expect(fc.scenario()
+    fc.scenario()
       .forall('t', fc.time())
       .then(({t}) => {
         return t.hour >= 0 && t.hour <= 23 &&
@@ -26,27 +25,27 @@ describe('DateTime tests', () => {
                t.millisecond >= 0 && t.millisecond <= 999
       })
       .check()
-    ).to.have.property('satisfiable', true)
+      .assertSatisfiable()
   })
 
   it('should generate valid datetime objects', () => {
     const MIN_DATE = new Date('2020-01-01')
     const MAX_DATE = new Date('2020-12-31')
 
-    expect(fc.scenario()
+    fc.scenario()
       .forall('dt', fc.datetime(MIN_DATE, MAX_DATE))
       .then(({dt}) => {
         return dt >= new Date(new Date(MIN_DATE.getTime()).setHours(0, 0, 0, 0)) &&
                dt <= new Date(new Date(MAX_DATE.getTime()).setHours(23, 59, 59, 999))
       })
       .check()
-    ).to.have.property('satisfiable', true)
+      .assertSatisfiable()
   })
 
   it('should generate valid duration objects', () => {
     const MAX_HOURS = 10
 
-    expect(fc.scenario()
+    fc.scenario()
       .forall('d', fc.duration(MAX_HOURS))
       .then(({d}) => {
         return d.hours >= 0 && d.hours <= MAX_HOURS &&
@@ -55,33 +54,33 @@ describe('DateTime tests', () => {
                d.milliseconds >= 0 && d.milliseconds <= 999
       })
       .check()
-    ).to.have.property('satisfiable', true)
+      .assertSatisfiable()
   })
 
   it('should correctly convert time objects to milliseconds', () => {
-    expect(fc.scenario()
+    fc.scenario()
       .forall('t', fc.time())
       .then(({t}) => {
         const ms = fc.timeToMilliseconds(t)
         return ms === (t.hour * 3600000 + t.minute * 60000 + t.second * 1000 + t.millisecond)
       })
       .check()
-    ).to.have.property('satisfiable', true)
+      .assertSatisfiable()
   })
 
   it('should correctly convert duration objects to milliseconds', () => {
-    expect(fc.scenario()
+    fc.scenario()
       .forall('d', fc.duration())
       .then(({d}) => {
         const ms = fc.timeToMilliseconds(d)
         return ms === (d.hours * 3600000 + d.minutes * 60000 + d.seconds * 1000 + d.milliseconds)
       })
       .check()
-    ).to.have.property('satisfiable', true)
+      .assertSatisfiable()
   })
 
   it('date addition property: adding days to a date should increase it by the correct amount', () => {
-    expect(fc.scenario()
+    fc.scenario()
       .forall('date', fc.date(new Date('2020-01-01'), new Date('2020-12-31')))
       .forall('days', fc.integer(1, 30))
       .then(({date, days}) => {
@@ -95,11 +94,11 @@ describe('DateTime tests', () => {
         return newDate.getTime() === expectedDate.getTime()
       })
       .check()
-    ).to.have.property('satisfiable', true)
+      .assertSatisfiable()
   })
 
   it('time addition property: adding hours should correctly wrap around', () => {
-    expect(fc.scenario()
+    fc.scenario()
       .forall('time', fc.time())
       .forall('hours', fc.integer(1, 48))
       .then(({time, hours}) => {
@@ -109,6 +108,6 @@ describe('DateTime tests', () => {
         return newHours >= 0 && newHours < 24
       })
       .check()
-    ).to.have.property('satisfiable', true)
+      .assertSatisfiable()
   })
 })

--- a/test/preconditions.test.ts
+++ b/test/preconditions.test.ts
@@ -12,7 +12,7 @@ describe('Precondition tests', () => {
       })
       .check()
 
-    expect(result.satisfiable).to.equal(true)
+    result.assertSatisfiable()
   })
 
   it('Basic precondition - test skips when precondition is false', () => {
@@ -55,7 +55,7 @@ describe('Precondition tests', () => {
       })
       .check()
 
-    expect(result.satisfiable).to.equal(true)
+    result.assertSatisfiable()
     expect(afterPreExecuted).to.equal(true)
   })
 
@@ -71,7 +71,7 @@ describe('Precondition tests', () => {
       })
       .check()
 
-    expect(result.satisfiable).to.equal(true)
+    result.assertSatisfiable()
   })
 
   it('Multiple preconditions - first failing skips the test', () => {
@@ -100,7 +100,7 @@ describe('Precondition tests', () => {
       })
       .check()
 
-    expect(result.satisfiable).to.equal(true)
+    result.assertSatisfiable()
     // Some cases with b=0 should have been skipped
     expect(result.skipped).to.be.greaterThan(0)
   })
@@ -117,7 +117,7 @@ describe('Precondition tests', () => {
       })
       .check()
 
-    expect(result.satisfiable).to.equal(true)
+    result.assertSatisfiable()
     expect(result.skipped).to.be.greaterThan(0)
   })
 
@@ -138,6 +138,6 @@ describe('Precondition tests', () => {
       })
       .check()
 
-    expect(result.satisfiable).to.equal(true)
+    result.assertSatisfiable()
   })
 })

--- a/test/presets.test.ts
+++ b/test/presets.test.ts
@@ -7,11 +7,11 @@ describe('Arbitrary Presets', () => {
   describe('Integer Presets', () => {
     describe('positiveInt()', () => {
       it('should only generate integers >= 1', () => {
-        expect(fc.scenario()
+        fc.scenario()
           .forall('n', fc.positiveInt())
           .then(({n}) => n >= 1)
           .check()
-        ).to.have.property('satisfiable', true)
+          .assertSatisfiable()
       })
 
       it('should generate values up to MAX_SAFE_INTEGER', () => {
@@ -34,11 +34,11 @@ describe('Arbitrary Presets', () => {
 
     describe('negativeInt()', () => {
       it('should only generate integers <= -1', () => {
-        expect(fc.scenario()
+        fc.scenario()
           .forall('n', fc.negativeInt())
           .then(({n}) => n <= -1)
           .check()
-        ).to.have.property('satisfiable', true)
+          .assertSatisfiable()
       })
 
       it('should generate values down to MIN_SAFE_INTEGER', () => {
@@ -61,11 +61,11 @@ describe('Arbitrary Presets', () => {
 
     describe('nonZeroInt()', () => {
       it('should never generate zero', () => {
-        expect(fc.scenario()
+        fc.scenario()
           .forall('n', fc.nonZeroInt())
           .then(({n}) => n !== 0)
           .check()
-        ).to.have.property('satisfiable', true)
+          .assertSatisfiable()
       })
 
       it('should generate both positive and negative integers', () => {
@@ -84,11 +84,11 @@ describe('Arbitrary Presets', () => {
 
     describe('byte()', () => {
       it('should only generate integers in range [0, 255]', () => {
-        expect(fc.scenario()
+        fc.scenario()
           .forall('n', fc.byte())
           .then(({n}) => n >= 0 && n <= 255)
           .check()
-        ).to.have.property('satisfiable', true)
+          .assertSatisfiable()
       })
 
       it('should have corner cases including 0 and 255', () => {
@@ -106,19 +106,19 @@ describe('Arbitrary Presets', () => {
   describe('String Presets', () => {
     describe('nonEmptyString()', () => {
       it('should only generate strings with length >= 1', () => {
-        expect(fc.scenario()
+        fc.scenario()
           .forall('s', fc.nonEmptyString())
           .then(({s}) => s.length >= 1)
           .check()
-        ).to.have.property('satisfiable', true)
+          .assertSatisfiable()
       })
 
       it('should respect maxLength parameter', () => {
-        expect(fc.scenario()
+        fc.scenario()
           .forall('s', fc.nonEmptyString(5))
           .then(({s}) => s.length >= 1 && s.length <= 5)
           .check()
-        ).to.have.property('satisfiable', true)
+          .assertSatisfiable()
       })
 
       it('should default to maxLength of 100', () => {
@@ -136,27 +136,27 @@ describe('Arbitrary Presets', () => {
   describe('Collection Presets', () => {
     describe('nonEmptyArray()', () => {
       it('should only generate arrays with length >= 1', () => {
-        expect(fc.scenario()
+        fc.scenario()
           .forall('arr', fc.nonEmptyArray(fc.integer()))
           .then(({arr}) => arr.length >= 1)
           .check()
-        ).to.have.property('satisfiable', true)
+          .assertSatisfiable()
       })
 
       it('should respect maxLength parameter', () => {
-        expect(fc.scenario()
+        fc.scenario()
           .forall('arr', fc.nonEmptyArray(fc.integer(), 3))
           .then(({arr}) => arr.length >= 1 && arr.length <= 3)
           .check()
-        ).to.have.property('satisfiable', true)
+          .assertSatisfiable()
       })
 
       it('should generate elements from the provided arbitrary', () => {
-        expect(fc.scenario()
+        fc.scenario()
           .forall('arr', fc.nonEmptyArray(fc.integer(0, 10)))
           .then(({arr}) => arr.every(n => n >= 0 && n <= 10))
           .check()
-        ).to.have.property('satisfiable', true)
+          .assertSatisfiable()
       })
 
       it('should never generate empty arrays', () => {
@@ -172,19 +172,19 @@ describe('Arbitrary Presets', () => {
 
     describe('pair()', () => {
       it('should generate 2-tuples', () => {
-        expect(fc.scenario()
+        fc.scenario()
           .forall('p', fc.pair(fc.integer()))
           .then(({p}) => Array.isArray(p) && p.length === 2)
           .check()
-        ).to.have.property('satisfiable', true)
+          .assertSatisfiable()
       })
 
       it('should generate both elements from the same arbitrary', () => {
-        expect(fc.scenario()
+        fc.scenario()
           .forall('p', fc.pair(fc.integer(0, 10)))
           .then(({p}) => p[0] >= 0 && p[0] <= 10 && p[1] >= 0 && p[1] <= 10)
           .check()
-        ).to.have.property('satisfiable', true)
+          .assertSatisfiable()
       })
 
       it('should work with different arbitrary types', () => {
@@ -209,11 +209,11 @@ describe('Arbitrary Presets', () => {
   describe('Nullable/Optional Presets', () => {
     describe('nullable()', () => {
       it('should generate values or null', () => {
-        expect(fc.scenario()
+        fc.scenario()
           .forall('v', fc.nullable(fc.integer(0, 10)))
           .then(({v}) => v === null || (typeof v === 'number' && v >= 0 && v <= 10))
           .check()
-        ).to.have.property('satisfiable', true)
+          .assertSatisfiable()
       })
 
       it('should sometimes generate null', () => {
@@ -238,11 +238,11 @@ describe('Arbitrary Presets', () => {
 
     describe('optional()', () => {
       it('should generate values or undefined', () => {
-        expect(fc.scenario()
+        fc.scenario()
           .forall('v', fc.optional(fc.integer(0, 10)))
           .then(({v}) => v === undefined || (typeof v === 'number' && v >= 0 && v <= 10))
           .check()
-        ).to.have.property('satisfiable', true)
+          .assertSatisfiable()
       })
 
       it('should sometimes generate undefined', () => {
@@ -327,20 +327,20 @@ describe('Arbitrary Presets', () => {
 
     it('nullable can wrap other presets', () => {
       const nullablePositive = fc.nullable(fc.positiveInt())
-      expect(fc.scenario()
+      fc.scenario()
         .forall('v', nullablePositive)
         .then(({v}) => v === null || v >= 1)
         .check()
-      ).to.have.property('satisfiable', true)
+        .assertSatisfiable()
     })
 
     it('nonEmptyArray can contain pairs', () => {
       const arrOfPairs = fc.nonEmptyArray(fc.pair(fc.byte()), 5)
-      expect(fc.scenario()
+      fc.scenario()
         .forall('arr', arrOfPairs)
         .then(({arr}) => arr.length >= 1 && arr.every(p => p.length === 2))
         .check()
-      ).to.have.property('satisfiable', true)
+        .assertSatisfiable()
     })
   })
 

--- a/test/regex.test.ts
+++ b/test/regex.test.ts
@@ -4,58 +4,58 @@ import {expect} from 'chai'
 
 describe('Regex tests', () => {
   it('should generate strings matching simple character class patterns', () => {
-    expect(fc.scenario()
+    fc.scenario()
       .forall('s', fc.regex(/[a-z]{3}/))
       .then(({s}) => {
         return /^[a-z]{3}$/.test(s)
       })
       .check()
-    ).to.have.property('satisfiable', true)
+      .assertSatisfiable()
   })
 
   it('should generate strings matching digit patterns', () => {
-    expect(fc.scenario()
+    fc.scenario()
       .forall('s', fc.regex(/\d{5}/))
       .then(({s}) => {
         return /^\d{5}$/.test(s) && s.length === 5
       })
       .check()
-    ).to.have.property('satisfiable', true)
+      .assertSatisfiable()
   })
 
   it('should generate strings matching word character patterns', () => {
-    expect(fc.scenario()
+    fc.scenario()
       .forall('s', fc.regex(/\w{1,5}/))  // Limiting the range to avoid memory issues
       .then(({s}) => {
         return /^\w{1,5}$/.test(s) && s.length >= 1 && s.length <= 5
       })
       .check()
-    ).to.have.property('satisfiable', true)
+      .assertSatisfiable()
   })
 
   it('should generate strings matching patterns with quantifiers', () => {
-    expect(fc.scenario()
+    fc.scenario()
       .forall('s', fc.regex(/a{2,4}/))
       .then(({s}) => {
         return /^a{2,4}$/.test(s) && s.length >= 2 && s.length <= 4
       })
       .check()
-    ).to.have.property('satisfiable', true)
+      .assertSatisfiable()
   })
 
   // Simplified alternatives test
   it('should generate strings matching patterns with alternatives', () => {
-    expect(fc.scenario()
+    fc.scenario()
       .forall('s', fc.regex(/(cat|dog)/))  // Simplified with explicit grouping
       .then(({s}) => {
         return s === 'cat' || s === 'dog'
       })
       .check()
-    ).to.have.property('satisfiable', true)
+      .assertSatisfiable()
   })
 
   it('should generate valid email addresses with patterns.email', () => {
-    expect(fc.scenario()
+    fc.scenario()
       .forall('email', fc.patterns.email())
       .then(({email}) => {
         // Test with a comprehensive email regex
@@ -63,11 +63,11 @@ describe('Regex tests', () => {
         return emailRegex.test(email) && email.includes('@')
       })
       .check()
-    ).to.have.property('satisfiable', true)
+      .assertSatisfiable()
   })
 
   it('should generate valid UUIDs with patterns.uuid', () => {
-    expect(fc.scenario()
+    fc.scenario()
       .forall('uuid', fc.patterns.uuid())
       .then(({uuid}) => {
         // UUID v4 format: 8-4-4-4-12 hex digits with version 4 format
@@ -75,11 +75,11 @@ describe('Regex tests', () => {
         return uuidRegex.test(uuid)
       })
       .check()
-    ).to.have.property('satisfiable', true)
+      .assertSatisfiable()
   })
 
   it('should generate valid IPv4 addresses with patterns.ipv4', () => {
-    expect(fc.scenario()
+    fc.scenario()
       .forall('ip', fc.patterns.ipv4())
       .then(({ip}) => {
         // Check format and valid octet ranges
@@ -92,17 +92,17 @@ describe('Regex tests', () => {
         })
       })
       .check()
-    ).to.have.property('satisfiable', true)
+      .assertSatisfiable()
   })
 
   it('should respect maxLength parameter in regex generation', () => {
-    expect(fc.scenario()
+    fc.scenario()
       .forall('s', fc.regex(/\w+/, 5))  // Reducing max length to avoid memory issues
       .then(({s}) => {
         return /^\w+$/.test(s) && s.length <= 5
       })
       .check()
-    ).to.have.property('satisfiable', true)
+      .assertSatisfiable()
   })
 
   it('should perform shrinking while maintaining regex pattern', () => {
@@ -131,13 +131,13 @@ describe('Regex tests', () => {
 
   // Simplified validation test
   it('should validate proper email format', () => {
-    expect(fc.scenario()
+    fc.scenario()
       .forall('email', fc.patterns.email())
       .then(({email}) => {
         // An email must contain exactly one @ symbol
         return String(email).includes('@') && String(email).includes('.')
       })
       .check()
-    ).to.have.property('satisfiable', true)
+      .assertSatisfiable()
   })
 })

--- a/test/types/const-type-params.types.ts
+++ b/test/types/const-type-params.types.ts
@@ -11,7 +11,7 @@
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import {oneof, set, tuple, integer, boolean, Arbitrary} from '../../src/arbitraries/index.js'
+import {oneof, set, tuple, integer, boolean, type Arbitrary} from '../../src/arbitraries/index.js'
 
 // ============================================================================
 // Type assertion utilities (standard type-testing pattern)

--- a/test/types/discriminated-unions.types.ts
+++ b/test/types/discriminated-unions.types.ts
@@ -12,9 +12,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import {
-  ArbitrarySize,
-  ExactSize,
-  EstimatedSize,
+  type ArbitrarySize,
+  type ExactSize,
+  type EstimatedSize,
   exactSize,
   estimatedSize,
   integer,

--- a/test/types/fluentresult.types.ts
+++ b/test/types/fluentresult.types.ts
@@ -11,7 +11,7 @@
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import {FluentCheck, FluentResult} from '../../src/FluentCheck.js'
+import {FluentCheck, type FluentResult} from '../../src/FluentCheck.js'
 import * as fc from '../../src/arbitraries/index.js'
 
 // ============================================================================

--- a/test/types/noinfer.types.ts
+++ b/test/types/noinfer.types.ts
@@ -12,7 +12,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import {FluentCheck} from '../../src/FluentCheck.js'
-import {integer, Arbitrary} from '../../src/arbitraries/index.js'
+import {integer, type Arbitrary} from '../../src/arbitraries/index.js'
 
 // ============================================================================
 // Type assertion utilities (standard type-testing pattern)

--- a/test/types/prop-shorthand.types.ts
+++ b/test/types/prop-shorthand.types.ts
@@ -11,7 +11,7 @@
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import {prop, FluentProperty} from '../../src/FluentProperty.js'
+import {prop, type FluentProperty} from '../../src/FluentProperty.js'
 import {integer, string, boolean, array} from '../../src/arbitraries/index.js'
 
 // ============================================================================
@@ -111,7 +111,7 @@ type _T7 = Expect<Equal<typeof chainedConfig, FluentProperty<[number, string]>>>
 // Test: check() returns FluentResult
 // ============================================================================
 
-import {FluentResult} from '../../src/FluentCheck.js'
+import {type FluentResult} from '../../src/FluentCheck.js'
 
 const checkResult = prop(integer(), x => x >= 0).check()
 type _T8 = Expect<Equal<typeof checkResult, FluentResult<Record<string, unknown>>>>


### PR DESCRIPTION
## Summary

- Add husky for git hooks management with pre-commit hook running lint and tests
- Add `lint:fix` script for convenience (`npm run lint:fix`)
- Migrate 51 test assertions from verbose chai pattern to built-in `assertSatisfiable()` helper
- ESLint config improvements and linting fixes

## Changes

**Pre-commit hooks:**
- Adds husky as dev dependency
- Creates `.husky/pre-commit` that runs `npm run lint` and `npm test`
- Updates `prepare` script to initialize husky on `npm install`

**Test cleanup:**
Replaces verbose pattern:
```typescript
expect(fc.scenario()...check()).to.have.property('satisfiable', true)
```
With cleaner:
```typescript
fc.scenario()...check().assertSatisfiable()
```

**ESLint & code quality:**
- Update to `es2025` globals
- Add `no-unnecessary-type-assertion` rule  
- Fix line length in `ArbitraryInteger.toString()`
- Remove unnecessary type assertion in `pair()` preset
- Remove unused `ArbitrarySize` import
- Use `type` keyword for type-only imports in test files

## Test plan

- [x] All 309 tests pass
- [x] Pre-commit hook runs successfully
- [x] `npm run lint:fix` works as expected
- [x] No lint warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set up Husky pre-commit to run lint/tests, add lint:fix, update ESLint globals/rules, minor source tweaks, and refactor tests to use assertSatisfiable with type-only imports.
> 
> - **Tooling**
>   - **Husky**: Add dev dependency and `.husky/pre-commit` to run `npm run lint` and `npm test`; update `prepare` script to init Husky.
>   - **NPM Scripts**: Add `lint:fix`.
>   - **ESLint**: Switch `globals` from `es2020` to `es2025`; enable `@typescript-eslint/no-unnecessary-type-assertion`.
> - **Source**
>   - `src/arbitraries/ArbitraryInteger.ts`: Reformat `toString` implementation.
>   - `src/arbitraries/presets.ts`: Simplify `pair()` return (remove redundant cast).
>   - `src/index.ts`: Remove unused type import.
> - **Tests**
>   - Replace Chai satisfiable assertions with `.assertSatisfiable()` across `test/**/*.ts`.
>   - Minor cleanups: drop unused `expect` import where not needed; convert several imports to type-only in `test/types/**/*.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d81ae81845a30ea4401c239cfb11d471459ddf6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->