### PR TITLE
refactor: migrate to native ES2022 private fields

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,7 +2,7 @@ import eslint from '@eslint/js'
 import tseslint from 'typescript-eslint'
 import globals from 'globals'
 
-export default tseslint.config(
+export default [
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
   {
@@ -50,6 +50,9 @@ export default tseslint.config(
       '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
       '@typescript-eslint/consistent-type-imports': ['warn', { prefer: 'type-imports', fixStyle: 'inline-type-imports' }],
       '@typescript-eslint/no-unnecessary-type-assertion': 'warn',
+      // Prefer native private fields (#field) over TypeScript private keyword for runtime privacy
+      // Note: No built-in ESLint rule exists to enforce this, but we prefer #field syntax
+      // for true runtime privacy. Use TypeScript `private` only when subclass access is needed.
 
       // Level 0 rules: disabled
       'no-console': 'off',
@@ -72,5 +75,5 @@ export default tseslint.config(
   },
   {
     ignores: ['dist/**', 'node_modules/**', 'coverage/**'],
-  }
-)
+  },
+]

--- a/openspec/changes/ts-modernise-private-fields/tasks.md
+++ b/openspec/changes/ts-modernise-private-fields/tasks.md
@@ -1,11 +1,11 @@
 ## 1. Implementation
 
-- [ ] 1.1 Identify all `private` fields and methods in `src/FluentCheck.ts`
-- [ ] 1.2 Convert `private runPreliminaries` to `#runPreliminaries`
-- [ ] 1.3 Convert other private methods in FluentCheck subclasses
-- [ ] 1.4 Review `src/arbitraries/*.ts` for private fields to convert
-- [ ] 1.5 Review `src/strategies/*.ts` for private fields to convert
-- [ ] 1.6 Update all internal references from `this.field` to `this.#field`
-- [ ] 1.7 Keep `private` for protected-like visibility where subclass access is needed
-- [ ] 1.8 Run full test suite to ensure no regressions
-- [ ] 1.9 Verify ES2022 target in tsconfig.json supports private fields
+- [x] 1.1 Identify all `private` fields and methods in `src/FluentCheck.ts`
+- [x] 1.2 Convert `private runPreliminaries` to `#runPreliminaries`
+- [x] 1.3 Convert other private methods in FluentCheck subclasses
+- [x] 1.4 Review `src/arbitraries/*.ts` for private fields to convert
+- [x] 1.5 Review `src/strategies/*.ts` for private fields to convert
+- [x] 1.6 Update all internal references from `this.field` to `this.#field`
+- [x] 1.7 Keep `private` for protected-like visibility where subclass access is needed
+- [x] 1.8 Run full test suite to ensure no regressions
+- [x] 1.9 Verify ES2022 target in tsconfig.json supports private fields

--- a/src/FluentCheck.ts
+++ b/src/FluentCheck.ts
@@ -143,7 +143,7 @@ export class FluentResult<Rec extends {} = {}> {
       const expectedValue = expected[key]
       const actualValue = this.example[key]
 
-      if (!this.deepEqual(expectedValue, actualValue)) {
+      if (!this.#deepEqual(expectedValue, actualValue)) {
         mismatches.push(`${String(key)}: expected ${JSON.stringify(expectedValue)}, got ${JSON.stringify(actualValue)}`)
       }
     }
@@ -158,14 +158,14 @@ export class FluentResult<Rec extends {} = {}> {
   /**
    * Deep equality comparison for values.
    */
-  private deepEqual(a: unknown, b: unknown): boolean {
+  #deepEqual(a: unknown, b: unknown): boolean {
     if (a === b) return true
     if (a === null || b === null) return false
     if (typeof a !== 'object' || typeof b !== 'object') return false
 
     if (Array.isArray(a) && Array.isArray(b)) {
       if (a.length !== b.length) return false
-      return a.every((val, i) => this.deepEqual(val, b[i]))
+      return a.every((val, i) => this.#deepEqual(val, b[i]))
     }
 
     if (Array.isArray(a) !== Array.isArray(b)) return false
@@ -176,7 +176,7 @@ export class FluentResult<Rec extends {} = {}> {
 
     return keysA.every(key =>
       Object.prototype.hasOwnProperty.call(b, key) &&
-      this.deepEqual((a as Record<string, unknown>)[key], (b as Record<string, unknown>)[key])
+      this.#deepEqual((a as Record<string, unknown>)[key], (b as Record<string, unknown>)[key])
     )
   }
 }
@@ -413,7 +413,7 @@ class FluentCheckAssert<Rec extends ParentRec, ParentRec extends {}> extends Flu
     return this.then(assertion)
   }
 
-  private runPreliminaries<T>(testCase: ValueResult<T>): Rec {
+  #runPreliminaries<T>(testCase: ValueResult<T>): Rec {
     const data: Record<string, unknown> = {}
 
     this.preliminaries.forEach(node => {
@@ -428,7 +428,7 @@ class FluentCheckAssert<Rec extends ParentRec, ParentRec extends {}> extends Flu
     callback: (arg: WrapFluentPick<Rec>) => FluentResult): FluentResult {
     const unwrappedTestCase = FluentCheck.unwrapFluentPick(testCase)
     try {
-      const passed = this.assertion({...unwrappedTestCase, ...this.runPreliminaries(unwrappedTestCase)} as Rec)
+      const passed = this.assertion({...unwrappedTestCase, ...this.#runPreliminaries(unwrappedTestCase)} as Rec)
       if (passed) {
         return callback(testCase)
       } else {

--- a/src/FluentProperty.ts
+++ b/src/FluentProperty.ts
@@ -74,31 +74,39 @@ export interface FluentProperty<Args extends unknown[]> {
  * Internal implementation of FluentProperty.
  */
 class FluentPropertyImpl<Args extends unknown[]> implements FluentProperty<Args> {
+  readonly #arbitraries: Arbitrary<unknown>[]
+  readonly #predicate: (...args: Args) => boolean
+  readonly #strategyFactory?: FluentStrategyFactory
+
   constructor(
-    private readonly arbitraries: Arbitrary<unknown>[],
-    private readonly predicate: (...args: Args) => boolean,
-    private readonly strategyFactory?: FluentStrategyFactory
-  ) {}
+    arbitraries: Arbitrary<unknown>[],
+    predicate: (...args: Args) => boolean,
+    strategyFactory?: FluentStrategyFactory
+  ) {
+    this.#arbitraries = arbitraries
+    this.#predicate = predicate
+    this.#strategyFactory = strategyFactory
+  }
 
   check(): FluentResult<Record<string, unknown>> {
     let checker = new FluentCheck()
 
-    if (this.strategyFactory !== undefined) {
-      checker = checker.config(this.strategyFactory)
+    if (this.#strategyFactory !== undefined) {
+      checker = checker.config(this.#strategyFactory)
     }
 
     // Build the chain with positional argument names
     let chain: FluentCheck<Record<string, unknown>, Record<string, unknown>> =
       checker as FluentCheck<Record<string, unknown>, Record<string, unknown>>
 
-    for (let i = 0; i < this.arbitraries.length; i++) {
-      chain = chain.forall(`arg${i}`, this.arbitraries[i])
+    for (let i = 0; i < this.#arbitraries.length; i++) {
+      chain = chain.forall(`arg${i}`, this.#arbitraries[i])
     }
 
     // Create the predicate wrapper that extracts positional arguments
     const wrappedPredicate = (args: Record<string, unknown>): boolean => {
-      const positionalArgs = this.arbitraries.map((_, i) => args[`arg${i}`]) as Args
-      return this.predicate(...positionalArgs)
+      const positionalArgs = this.#arbitraries.map((_, i) => args[`arg${i}`]) as Args
+      return this.#predicate(...positionalArgs)
     }
 
     return chain.then(wrappedPredicate).check()
@@ -109,7 +117,7 @@ class FluentPropertyImpl<Args extends unknown[]> implements FluentProperty<Args>
     if (!result.satisfiable) {
       const prefix = message !== undefined && message !== '' ? `${message}: ` : ''
       // Extract positional arguments for cleaner error message
-      const args = this.arbitraries.map((_, i) => result.example[`arg${i}`])
+      const args = this.#arbitraries.map((_, i) => result.example[`arg${i}`])
       const argsStr = args.length === 1
         ? JSON.stringify(args[0])
         : `(${args.map(a => JSON.stringify(a)).join(', ')})`
@@ -119,7 +127,7 @@ class FluentPropertyImpl<Args extends unknown[]> implements FluentProperty<Args>
   }
 
   config(strategyFactory: FluentStrategyFactory): FluentProperty<Args> {
-    return new FluentPropertyImpl(this.arbitraries, this.predicate, strategyFactory)
+    return new FluentPropertyImpl(this.#arbitraries, this.#predicate, strategyFactory)
   }
 }
 

--- a/src/statistics.ts
+++ b/src/statistics.ts
@@ -82,7 +82,7 @@ export class BetaDistribution extends Distribution {
 export class BetaBinomialDistribution extends IntegerDistribution {
   constructor(public trials: number, public alpha: number, public beta: number) { super() }
 
-  pdf(x: number): number { return Math.exp(this.logPdf(x)) }
+  pdf(x: number): number { return Math.exp(this.#logPdf(x)) }
   supportMin(): number { return 0 }
   supportMax(): number { return this.trials }
 
@@ -99,22 +99,22 @@ export class BetaBinomialDistribution extends IntegerDistribution {
   // TODO: implement efficient calculation of CDF (currently O(trials))
   // cdf(k: number): number
 
-  private logPdf(x: number) {
-    return this.combinationln(this.trials, x) +
-      this.betaln(x + this.alpha, this.trials - x + this.beta) -
-      this.betaln(this.alpha, this.beta)
+  #logPdf(x: number) {
+    return this.#combinationln(this.trials, x) +
+      this.#betaln(x + this.alpha, this.trials - x + this.beta) -
+      this.#betaln(this.alpha, this.beta)
   }
 
   // Helper functions since jstat's API changed
-  private combinationln(n: number, k: number): number {
-    return this.factorialln(n) - this.factorialln(k) - this.factorialln(n - k)
+  #combinationln(n: number, k: number): number {
+    return this.#factorialln(n) - this.#factorialln(k) - this.#factorialln(n - k)
   }
 
-  private betaln(a: number, b: number): number {
+  #betaln(a: number, b: number): number {
     return jstat.gammaln(a) + jstat.gammaln(b) - jstat.gammaln(a + b)
   }
 
-  private factorialln(n: number): number {
+  #factorialln(n: number): number {
     return jstat.gammaln(n + 1)
   }
 }

--- a/src/strategies/FluentStrategyFactory.ts
+++ b/src/strategies/FluentStrategyFactory.ts
@@ -6,7 +6,7 @@ export class FluentStrategyFactory {
   /**
    * Strategy mixin composition
    */
-  private strategy: new (config: FluentConfig) => FluentStrategy = FluentStrategy
+  #strategy: new (config: FluentConfig) => FluentStrategy = FluentStrategy
 
   /**
    * Strategy configuration
@@ -25,7 +25,7 @@ export class FluentStrategyFactory {
    * Enables sampling without replacement, which avoids testing duplicate test cases.
    */
   withoutReplacement() {
-    this.strategy = Dedupable(this.strategy)
+    this.#strategy = Dedupable(this.#strategy)
     return this
   }
 
@@ -33,7 +33,7 @@ export class FluentStrategyFactory {
    * Sampling considers corner cases.
    */
   withBias() {
-    this.strategy = Biased(this.strategy)
+    this.#strategy = Biased(this.#strategy)
     return this
   }
 
@@ -41,7 +41,7 @@ export class FluentStrategyFactory {
    * Caches the generated samples to avoid being constantly generating new samples.
    */
   usingCache() {
-    this.strategy = Cached(this.strategy)
+    this.#strategy = Cached(this.#strategy)
     return this
   }
 
@@ -49,7 +49,7 @@ export class FluentStrategyFactory {
    * Randomly generates test cases.
    */
   withRandomSampling() {
-    this.strategy = Random(this.strategy)
+    this.#strategy = Random(this.#strategy)
     return this
   }
 
@@ -58,7 +58,7 @@ export class FluentStrategyFactory {
    */
   withShrinking(shrinkSize = 500) {
     this.configuration = {...this.configuration, shrinkSize}
-    this.strategy = Shrinkable(this.strategy)
+    this.#strategy = Shrinkable(this.#strategy)
     return this
   }
 
@@ -67,7 +67,7 @@ export class FluentStrategyFactory {
    */
   defaultStrategy() {
     this.configuration = {...this.configuration, shrinkSize: 500}
-    this.strategy = Shrinkable(Cached(Biased(Dedupable(Random(this.strategy)))))
+    this.#strategy = Shrinkable(Cached(Biased(Dedupable(Random(this.#strategy)))))
     return this
   }
 
@@ -75,7 +75,7 @@ export class FluentStrategyFactory {
    * Builds and returns the FluentStrategy with a specified configuration.
    */
   build(): FluentStrategy {
-    return new this.strategy(this.configuration)
+    return new this.#strategy(this.configuration)
   }
 
 }


### PR DESCRIPTION
## Summary

Implements openspec change proposal to migrate from TypeScript's `private` keyword to native ES2022 private fields (`#field`) for true runtime privacy.

**Proposal:** openspec/changes/ts-modernise-private-fields/proposal.md
**Closes:** #382

## Changes

- Converted all `private` fields and methods to use `#` prefix syntax
- Updated internal references from `this.field` to `this.#field`
- Fixed deprecated `tseslint.config()` usage in ESLint config
- All 309 tests pass
- OpenSpec validation passes

## Test Plan

- [x] All existing tests pass
- [x] New tests added for changed behavior (N/A - internal implementation detail)
- [x] `openspec validate ts-modernise-private-fields --strict` passes